### PR TITLE
Changing multiple destination configuration

### DIFF
--- a/modules/samples/artifacts/0004/RoundRobinPlan.siddhi
+++ b/modules/samples/artifacts/0004/RoundRobinPlan.siddhi
@@ -4,10 +4,10 @@
 
 define stream UsageInputStream (houseId int, maxVal float, minVal float, avgVal double);
 
-@sink(type='tcp', url='tcp://localhost:9893/UsageStream',context='UsageStream', @map(type='binary'),
+@sink(type='tcp',context='UsageStream', @map(type='binary'),
         @distribution(strategy='roundRobin',
-            @destination(port = '8081'),
-            @destination(port = '8082')))
+            @destination( url='tcp://localhost:8081/UsageStream'),
+            @destination( url='tcp://localhost:8082/UsageStream')))
 define stream UsageStream (houseId int, maxVal float, minVal float, avgVal double);
 
 from UsageInputStream


### PR DESCRIPTION
changing sample  for Publishing Events to Multiple Destinations Using the Round Robin Strategy as the  sink requires multiple destinations to be mentioned inside distribution annotation. 