### PR TITLE
Kernel 5.2.0 migration

### DIFF
--- a/modules/samples/sample-clients/wso2event-client/build.xml
+++ b/modules/samples/sample-clients/wso2event-client/build.xml
@@ -41,7 +41,7 @@
             <include name="slf4j.api_*.jar"/>
             <include name="org.yaml.snakeyaml_*.jar"/>
             <include name="disruptor_*.jar"/>
-            <include name="org.wso2.carbon.config_2.0.*.jar"/>
+            <include name="org.wso2.carbon.config_2.1.*.jar"/>
             <include name="org.wso2.carbon.secvault_5.0.*.jar"/>
             <include name="org.wso2.carbon.utils_2.0.*.jar"/>
             <include name="org.wso2.carbon.databridge.agent_6.0.*.jar"/>

--- a/modules/samples/sample-clients/wso2event-server/build.xml
+++ b/modules/samples/sample-clients/wso2event-server/build.xml
@@ -40,7 +40,7 @@
             <include name="slf4j.log4j12_1.7.*.jar"/>
             <include name="slf4j.api_*.jar"/>
             <include name="json_*.jar"/>
-            <include name="org.wso2.carbon.config_2.0.*.jar"/>
+            <include name="org.wso2.carbon.config_2.1.*.jar"/>
             <include name="org.wso2.carbon.secvault_5.0.*.jar"/>
             <include name="org.wso2.carbon.utils_2.0.*.jar"/>
             <include name="org.wso2.carbon.databridge.commons.thrift_6.0.*.jar"/>

--- a/pom.xml
+++ b/pom.xml
@@ -763,7 +763,7 @@
         <carbon.config.version.range>[2.1.0, 3.0.0)</carbon.config.version.range>
         <carbon.securevault.version>5.0.10</carbon.securevault.version>
 
-        <carbon.analytics-common.version>6.0.4</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.0.5-SNAPSHOT</carbon.analytics-common.version>
 
         <slf4j.version>1.7.5</slf4j.version>
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)

--- a/pom.xml
+++ b/pom.xml
@@ -763,7 +763,7 @@
         <carbon.config.version.range>[2.1.0, 3.0.0)</carbon.config.version.range>
         <carbon.securevault.version>5.0.10</carbon.securevault.version>
 
-        <carbon.analytics-common.version>6.0.5-SNAPSHOT</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.0.4</carbon.analytics-common.version>
 
         <slf4j.version>1.7.5</slf4j.version>
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)

--- a/pom.xml
+++ b/pom.xml
@@ -715,7 +715,7 @@
     </build>
 
     <properties>
-        <carbon.analytics.version>2.0.107</carbon.analytics.version>
+        <carbon.analytics.version>2.0.108-SNAPSHOT</carbon.analytics.version>
         <siddhi.version>4.0.0-M115</siddhi.version>
 
         <!-- Maven plugins -->

--- a/pom.xml
+++ b/pom.xml
@@ -715,7 +715,7 @@
     </build>
 
     <properties>
-        <carbon.analytics.version>2.0.105</carbon.analytics.version>
+        <carbon.analytics.version>2.0.107</carbon.analytics.version>
         <siddhi.version>4.0.0-M115</siddhi.version>
 
         <!-- Maven plugins -->
@@ -738,9 +738,9 @@
         <osgi.service.tracker.import.version.range>[1.5.1, 2.0.0)</osgi.service.tracker.import.version.range>
 
         <!-- Dependencies -->
-        <carbon.kernel.version>5.2.0-alpha</carbon.kernel.version>
-        <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.kernel.pax.version>5.2.0-alpha</carbon.kernel.pax.version>
+        <carbon.kernel.version>5.2.0</carbon.kernel.version>
+        <carbon.kernel.package.import.version.range>[5.2.0, 6.0.0)</carbon.kernel.package.import.version.range>
+        <carbon.kernel.pax.version>5.2.0</carbon.kernel.pax.version>
 
         <org.wso2.carbon.transport.http.netty.version>5.0.1</org.wso2.carbon.transport.http.netty.version>
         <carbon.transport.package.import.version.range>[4.0.0, 6.0.0)</carbon.transport.package.import.version.range>
@@ -752,18 +752,18 @@
         <carbon.deployment.version>5.1.5</carbon.deployment.version>
         <carbon.deployment.export.version>5.1.5</carbon.deployment.export.version>
 
-        <carbon.datasources.version>1.1.3</carbon.datasources.version>
-        <carbon.metrics.version>2.3.2</carbon.metrics.version>
-        <carbon.jndi.version>1.0.4</carbon.jndi.version>
+        <carbon.datasources.version>1.1.4</carbon.datasources.version>
+        <carbon.metrics.version>2.3.3</carbon.metrics.version>
+        <carbon.jndi.version>1.0.5</carbon.jndi.version>
 
         <carbon.cache.version>1.1.3</carbon.cache.version>
-        <carbon.touchpoint.version>1.1.0</carbon.touchpoint.version>
-        <carbon.utils.version>2.0.2</carbon.utils.version>
-        <carbon.config.version>2.0.5</carbon.config.version>
-        <carbon.config.version.range>[2.0.0, 3.0.0)</carbon.config.version.range>
-        <carbon.securevault.version>5.0.8</carbon.securevault.version>
+        <carbon.touchpoint.version>1.1.1</carbon.touchpoint.version>
+        <carbon.utils.version>2.0.4</carbon.utils.version>
+        <carbon.config.version>2.1.4</carbon.config.version>
+        <carbon.config.version.range>[2.1.0, 3.0.0)</carbon.config.version.range>
+        <carbon.securevault.version>5.0.10</carbon.securevault.version>
 
-        <carbon.analytics-common.version>6.0.2</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.0.4</carbon.analytics-common.version>
 
         <slf4j.version>1.7.5</slf4j.version>
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)


### PR DESCRIPTION
## Purpose
Upgrading the dependencies to Kernel 5.2.0

## Goals
Having the latest kernel dependencies in product-sp

## Related PRs
https://github.com/wso2/carbon-analytics-common/pull/389
https://github.com/wso2/carbon-metrics/pull/65
https://github.com/wso2/carbon-analytics/pull/540

