### PR TITLE
bumping carbon dashboards version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -816,7 +816,7 @@
         <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
         <carbon.coordination.version>2.0.7</carbon.coordination.version>
         <!--Dashboard-->
-        <carbon.dashboards.version>4.0.0.m10</carbon.dashboards.version>
+        <carbon.dashboards.version>4.0.0.m15</carbon.dashboards.version>
         <carbon.uis.version>0.10.4</carbon.uis.version>
 
         <!-- json dependencies -->


### PR DESCRIPTION
## Purpose
Bump carbon dashboards version from 4.0.0.m10 to 4.0.0.m15

## Goals
4.0.0.m15 contains bug fixes for several issues reported on carbon dashboards
