### PR TITLE
Add dashboard samples feature & bump dashboard version to 4.0.0.m17

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -240,6 +240,13 @@
             <type>zip</type>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.dashboards.samples</groupId>
+            <artifactId>org.wso2.carbon.dashboards.samples.feature</artifactId>
+            <version>${carbon.dashboards.version}</version>
+            <type>zip</type>
+        </dependency>
+        <!--Carbon UI Server-->
+        <dependency>
             <groupId>org.wso2.carbon.uis</groupId>
             <artifactId>org.wso2.carbon.uis.feature</artifactId>
             <type>zip</type>
@@ -729,6 +736,11 @@
                                     <version>${carbon.dashboards.version}</version>
                                 </feature>
                                 <feature>
+                                    <id>org.wso2.carbon.dashboards.samples.feature</id>
+                                    <version>${carbon.dashboards.version}</version>
+                                </feature>
+                                <!--Status Dashboard-->
+                                <feature>
                                     <id>org.wso2.carbon.status.dashboard.core.feature</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
@@ -736,6 +748,7 @@
                                     <id>org.wso2.carbon.status.dashboard.web.feature</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
+                                <!--Carbon UI Server-->
                                 <feature>
                                     <id>org.wso2.carbon.uis.feature</id>
                                     <version>${carbon.uis.version}</version>
@@ -1343,6 +1356,11 @@
                                     <version>${carbon.dashboards.version}</version>
                                 </feature>
                                 <feature>
+                                    <id>org.wso2.carbon.dashboards.samples.feature</id>
+                                    <version>${carbon.dashboards.version}</version>
+                                </feature>
+                                <!--Status Dahsboard-->
+                                <feature>
                                     <id>org.wso2.carbon.status.dashboard.core.feature</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
@@ -1350,6 +1368,7 @@
                                     <id>org.wso2.carbon.status.dashboard.web.feature</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
+                                <!--Carbon UI Server-->
                                 <feature>
                                     <id>org.wso2.carbon.uis.feature</id>
                                     <version>${carbon.uis.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -625,11 +625,19 @@
                 <type>zip</type>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.dashboards.samples</groupId>
+                <artifactId>org.wso2.carbon.dashboards.samples.feature</artifactId>
+                <version>${carbon.dashboards.version}</version>
+                <type>zip</type>
+            </dependency>
+            <!--Carbon UI Server-->
+            <dependency>
                 <groupId>org.wso2.carbon.uis</groupId>
                 <artifactId>org.wso2.carbon.uis.feature</artifactId>
                 <version>${carbon.uis.version}</version>
                 <type>zip</type>
             </dependency>
+            <!-- Authentication feature -->
             <dependency>
                 <groupId>org.wso2.carbon.analytics-common</groupId>
                 <artifactId>org.wso2.carbon.analytics.idp.client</artifactId>
@@ -842,7 +850,7 @@
         <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
         <carbon.coordination.version>2.0.7</carbon.coordination.version>
         <!--Dashboard-->
-        <carbon.dashboards.version>4.0.0.m15</carbon.dashboards.version>
+        <carbon.dashboards.version>4.0.0.m17</carbon.dashboards.version>
         <carbon.uis.version>0.10.4</carbon.uis.version>
 
         <!-- json dependencies -->


### PR DESCRIPTION
## Purpose
This PR adds `org.wso2.carbon.dashboards.samples.feature` samples feature and bumps `carbon-dashboards` version to v4.0.0.m17.

## Goals
Add dashboard samples feature & bump dashboard version to 4.0.0.m17

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
