### PR TITLE
Bump carbon-dashboards to 4.0.0-alpha

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -842,7 +842,7 @@
         <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
         <carbon.coordination.version>2.0.7</carbon.coordination.version>
         <!--Dashboard-->
-        <carbon.dashboards.version>4.0.0.m15</carbon.dashboards.version>
+        <carbon.dashboards.version>4.0.0-alpha</carbon.dashboards.version>
         <carbon.uis.version>0.10.4</carbon.uis.version>
 
         <!-- json dependencies -->


### PR DESCRIPTION
## Purpose
This PR bumps carbon-dashboards version to 4.0.0-alpha.