### PR TITLE
Removing unnecessary directories in wso2/manager/conf/transports

### DIFF
--- a/modules/distribution/carbon-home/conf/manager/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/manager/deployment.yaml
@@ -235,7 +235,7 @@ deployment.config:
   type: distributed
   httpInterface:
     host: localhost
-    port: 9090
+    port: 9190
   heartbeatInterval: 2000
   heartbeatMaxRetry: 2
   datasource: WSO2_CLUSTER_DB     # define a mysql datasource in datasources and refer it from here.

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -72,7 +72,7 @@
         </fileSet>
 
         <fileSet>
-            <directory>carbon-home/conf/transports</directory>
+            <directory>carbon-home/conf/transports/manager</directory>
             <outputDirectory>wso2/manager/conf/transports</outputDirectory>
             <fileMode>644</fileMode>
         </fileSet>
@@ -92,11 +92,6 @@
             <fileMode>644</fileMode>
         </fileSet>
 
-        <fileSet>
-            <directory>carbon-home/conf/transports/manager</directory>
-            <outputDirectory>wso2/manager/conf/transports</outputDirectory>
-            <fileMode>644</fileMode>
-        </fileSet>
         <fileSet>
             <directory>carbon-home/conf/osgi</directory>
             <outputDirectory>conf/osgi</outputDirectory>


### PR DESCRIPTION
## Purpose
> Currently transport configuration directories of other runtimes will get copied to the manager runtime's transport conf directory.  Therefore, removing those unnecessary directories in wso2/manager/conf/transports
