### PR TITLE
Bump carbon-dashboards version to 4.0.0.alpha2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -852,7 +852,7 @@
         <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
         <carbon.coordination.version>2.0.7</carbon.coordination.version>
         <!--Dashboard-->
-        <carbon.dashboards.version>4.0.0-alpha</carbon.dashboards.version>
+        <carbon.dashboards.version>4.0.0.alpha2</carbon.dashboards.version>
         <carbon.uis.version>0.10.4</carbon.uis.version>
 
         <!-- json dependencies -->


### PR DESCRIPTION
## Purpose
Current carbon-dashboards version is `4.0.0-alpha`

## Goals
Bump carbon-dashboards version to `4.0.0.alpha2`

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
