### PR TITLE
Resolving the error occurred when trying to start two tcp servers in sample 04

### DIFF
--- a/modules/samples/sample-clients/tcp-server/src/main/java/org/wso2/sp/tcp/server/TCPServer.java
+++ b/modules/samples/sample-clients/tcp-server/src/main/java/org/wso2/sp/tcp/server/TCPServer.java
@@ -80,8 +80,17 @@ public class TCPServer {
         });
 
         ServerConfig serverConfig = new ServerConfig();
-        serverConfig.setHost("localhost");
-        serverConfig.setPort(Integer.parseInt("9893"));
+        String host = "localhost";
+        String port = "9893";
+        if (args[0] != null && !args[0].equals("")) {
+            host = args[0];
+        }
+        if (args[1] != null && !args[1].equals("")) {
+            port = args[1];
+        }
+        
+        serverConfig.setHost(host);
+        serverConfig.setPort(Integer.parseInt(port));
 
         tcpNettyServer.start(serverConfig);
         try {


### PR DESCRIPTION
## Purpose
Resolving the error occured when trying to start two tcp servers using ant -Dport=<port> command

## Goals
N/A

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
  N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
sample 04, sample tcp server

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A