### PR TITLE
Adding fixes for checkstyle violations detected when building in windows

### DIFF
--- a/modules/samples/sample-clients/http-client/src/main/java/org/wso2/sp/http/client/HttpClient.java
+++ b/modules/samples/sample-clients/http-client/src/main/java/org/wso2/sp/http/client/HttpClient.java
@@ -39,7 +39,7 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 
 /**
- * This is a sample HTTP client to publish events to HTTP/HTTPS endpoint
+ * This is a sample HTTP client to publish events to HTTP/HTTPS endpoint.
  */
 public class HttpClient {
 

--- a/modules/samples/sample-clients/kafka-consumer/src/main/java/org/wso2/sp/sample/kafka/consumer/KafkaReceiver.java
+++ b/modules/samples/sample-clients/kafka-consumer/src/main/java/org/wso2/sp/sample/kafka/consumer/KafkaReceiver.java
@@ -31,12 +31,12 @@ import java.util.List;
 import java.util.Properties;
 
 /**
- * Test client for Kafka source
+ * Test client for Kafka source.
  */
 public class KafkaReceiver {
     private static final Logger log = Logger.getLogger(KafkaReceiver.class);
     /**
-     * Main method to start the test client
+     * Main method to start the test client.
      *
      * @param args no args need to be provided
      */

--- a/modules/samples/sample-clients/kafka-producer/src/main/java/org/wso2/sp/sample/kafka/client/KafkaClient.java
+++ b/modules/samples/sample-clients/kafka-producer/src/main/java/org/wso2/sp/sample/kafka/client/KafkaClient.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Properties;
 
 /**
- * Test client for Kafka source
+ * Test client for Kafka source.
  */
 public class KafkaClient {
     private static String sampleFilPath =
@@ -44,7 +44,7 @@ public class KafkaClient {
     private static Logger log = Logger.getLogger(KafkaClient.class);
 
     /**
-     * Main method to start the test client
+     * Main method to start the test client.
      *
      * @param args no args need to be provided
      */
@@ -147,7 +147,7 @@ public class KafkaClient {
     }
 
     /**
-     * messages will be read from the given filepath and stored in the array list (messagesList)
+     * messages will be read from the given filepath and stored in the array list (messagesList).
      *
      * @param filePath Text file to be read
      */

--- a/modules/samples/sample-clients/tcp-client/src/main/java/org/wso2/sp/tcp/client/StoreTestClient.java
+++ b/modules/samples/sample-clients/tcp-client/src/main/java/org/wso2/sp/tcp/client/StoreTestClient.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Store test client
+ * Store test client.
  */
 public class StoreTestClient {
     private static final String STREAM_NAME = "TestData";
@@ -38,7 +38,7 @@ public class StoreTestClient {
     private static final Logger LOG = Logger.getLogger(StoreTestClient.class);
 
     /**
-     * Main method to start the test client
+     * Main method to start the test client.
      *
      * @param args host and port need to be provided as args
      */

--- a/modules/samples/sample-clients/tcp-client/src/main/java/org/wso2/sp/tcp/client/TCPClient.java
+++ b/modules/samples/sample-clients/tcp-client/src/main/java/org/wso2/sp/tcp/client/TCPClient.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * Test client for TCP source
+ * Test client for TCP source.
  */
 public class TCPClient {
     private static final int EVENT_COUNT = 100;
@@ -46,7 +46,7 @@ public class TCPClient {
     private static final Logger LOG = Logger.getLogger(TCPClient.class);
 
     /**
-     * Main method to start the test client
+     * Main method to start the test client.
      *
      * @param args host and port need to be provided as args
      */

--- a/modules/samples/sample-clients/tcp-server/src/main/java/org/wso2/sp/tcp/server/TCPServer.java
+++ b/modules/samples/sample-clients/tcp-server/src/main/java/org/wso2/sp/tcp/server/TCPServer.java
@@ -30,13 +30,13 @@ import org.wso2.siddhi.query.api.definition.StreamDefinition;
 import java.nio.ByteBuffer;
 
 /**
- * Test Server for TCP source
+ * Test Server for TCP source.
  */
 public class TCPServer {
     static Logger log = Logger.getLogger(TCPServer.class);
 
     /**
-     * Main method to start the test Server
+     * Main method to start the test Server.
      *
      * @param args host and port are passed as args
      */

--- a/modules/samples/sample-clients/wso2event-client/src/main/java/org/wso2/carbon/sample/wso2event/Client.java
+++ b/modules/samples/sample-clients/wso2event-client/src/main/java/org/wso2/carbon/sample/wso2event/Client.java
@@ -28,7 +28,7 @@ import org.wso2.carbon.databridge.commons.utils.DataBridgeCommonsUtils;
 import java.util.Arrays;
 
 /**
- * WSO2Event Client Publisher
+ * WSO2Event Client Publisher.
  */
 public class Client {
     private static Log log = LogFactory.getLog(Client.class);

--- a/modules/samples/sample-clients/wso2event-client/src/main/java/org/wso2/carbon/sample/wso2event/DataPublisherUtil.java
+++ b/modules/samples/sample-clients/wso2event-client/src/main/java/org/wso2/carbon/sample/wso2event/DataPublisherUtil.java
@@ -21,7 +21,7 @@ package org.wso2.carbon.sample.wso2event;
 import java.io.File;
 
 /**
- * Datapublisher Util Implementataion
+ * Datapublisher Util Implementataion.
  */
 public class DataPublisherUtil {
 

--- a/modules/samples/sample-clients/wso2event-server/src/main/java/org/wso2/carbon/sample/server/DatabridgeTestServer.java
+++ b/modules/samples/sample-clients/wso2event-server/src/main/java/org/wso2/carbon/sample/server/DatabridgeTestServer.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * Databridge Thrift Server which accepts Thrift/Binary events
+ * Databridge Thrift Server which accepts Thrift/Binary events.
  */
 public class DatabridgeTestServer {
     private static final String STREAM_NAME = "org.wso2.esb.MediatorStatistics";

--- a/modules/samples/sample-clients/wso2event-server/src/main/java/org/wso2/carbon/sample/server/WSO2EventServerUtil.java
+++ b/modules/samples/sample-clients/wso2event-server/src/main/java/org/wso2/carbon/sample/server/WSO2EventServerUtil.java
@@ -21,7 +21,7 @@ package org.wso2.carbon.sample.server;
 import java.io.File;
 
 /**
- * Util class which sets Keystore and Databridge configuration
+ * Util class which sets Keystore and Databridge configuration.
  */
 public class WSO2EventServerUtil {
 


### PR DESCRIPTION
## Purpose
This pr contain a fix for checkstyle detected bugs when building in windows. There is a bug in checkstyles that some checkstyle violations are not detected in linux, but detected when building the project in windows.

## Goals
Removes checkstyle detected bugs.

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
  N/A
 - Integration tests
  N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A