### PR TITLE
Bump carbon-dashboards version

### DIFF
--- a/modules/distribution/carbon-home/conf/dashboard/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/dashboard/deployment.yaml
@@ -204,15 +204,6 @@ wso2.securevault:
     parameters:
       masterKeyReaderFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml
 
-# Dashboard related configurations
-wso2.dashboard:
-  queries:
-    h2:
-      add_dashboard: INSERT INTO DASHBOARD_RESOURCE (DASHBOARD_URL, DASHBOARD_NAME, DASHBOARD_DESCRIPTION, DASHBOARD_PARENT_ID , DASHBOARD_LANDING_PAGE, DASHBOARD_CONTENT) VALUES (?, ?, ?, ?, ?, ?)
-      get_dashboard_by_url: SELECT DASHBOARD_ID, DASHBOARD_URL, DASHBOARD_NAME, DASHBOARD_DESCRIPTION, DASHBOARD_PARENT_ID, DASHBOARD_LANDING_PAGE, DASHBOARD_CONTENT FROM DASHBOARD_RESOURCE WHERE DASHBOARD_URL = ?
-      get_dashboard_metadata_list: SELECT DASHBOARD_ID, DASHBOARD_URL, DASHBOARD_NAME, DASHBOARD_DESCRIPTION, DASHBOARD_PARENT_ID, DASHBOARD_LANDING_PAGE FROM DASHBOARD_RESOURCE
-      delete_dashboard_by_url: DELETE FROM DASHBOARD_RESOURCE WHERE DASHBOARD_URL = ?
-      update_dashboard_content: MERGE INTO DASHBOARD_RESOURCE (DASHBOARD_NAME, DASHBOARD_DESCRIPTION, DASHBOARD_CONTENT, DASHBOARD_URL, DASHBOARD_PARENT_ID, DASHBOARD_LANDING_PAGE) KEY(DASHBOARD_URL) VALUES( ?, ?, ?, ?, ?, ?)
 
 # Data Sources Configuration
 wso2.datasources:
@@ -281,6 +272,24 @@ wso2.datasources:
       type: RDBMS
       configuration:
         jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/dashboard/database/metrics;AUTO_SERVER=TRUE'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+
+  - name: WSO2_PERMISSIONS_DB
+    description: The datasource used for dashboard feature
+    jndiConfig:
+      name: jdbc/PERMISSION_DB
+      useJndiReference: true
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/PERMISSION_DB;IFEXISTS=TRUE;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
         username: wso2carbon
         password: wso2carbon
         driverClassName: org.h2.Driver

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -235,6 +235,13 @@
             <type>zip</type>
         </dependency>
 
+        <!-- Permission module -->
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.analytics.permissions.feature</artifactId>
+            <type>zip</type>
+        </dependency>
+
         <!--Dashboard-->
         <dependency>
             <groupId>org.wso2.carbon.dashboards</groupId>
@@ -736,6 +743,12 @@
 
                                 <feature>
                                     <id>org.wso2.carbon.analytics.auth.rest.api.feature</id>
+                                    <version>${carbon.analytics-common.version}</version>
+                                </feature>
+
+                                <!-- Permission module -->
+                                <feature>
+                                    <id>org.wso2.carbon.analytics.permissions.feature</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
 
@@ -1453,6 +1466,13 @@
                                     <id>org.wso2.carbon.analytics.auth.rest.api.feature</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
+
+                                <!-- Permission module -->
+                                <feature>
+                                    <id>org.wso2.carbon.analytics.permissions.feature</id>
+                                    <version>${carbon.analytics-common.version}</version>
+                                </feature>
+
                                 <!-- Databridge feature -->
                                 <feature>
                                     <id>org.wso2.carbon.databridge.feature</id>

--- a/pom.xml
+++ b/pom.xml
@@ -651,6 +651,18 @@
                 <type>zip</type>
             </dependency>
 
+            <dependency>
+                <groupId>org.wso2.carbon.analytics-common</groupId>
+                <artifactId>org.wso2.carbon.analytics.permissions</artifactId>
+                <version>${carbon.analytics-common.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.analytics-common</groupId>
+                <artifactId>org.wso2.carbon.analytics.permissions.feature</artifactId>
+                <version>${carbon.analytics-common.version}</version>
+                <type>zip</type>
+            </dependency>
+
             <!-- Data Provider -->
             <dependency>
                 <groupId>org.wso2.carbon.analytics-common</groupId>
@@ -851,7 +863,7 @@
         <carbon.config.version.range>[2.1.0, 3.0.0)</carbon.config.version.range>
         <carbon.securevault.version>5.0.10</carbon.securevault.version>
 
-        <carbon.analytics-common.version>6.0.7</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.0.9</carbon.analytics-common.version>
 
         <slf4j.version>1.7.5</slf4j.version>
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)
@@ -860,7 +872,7 @@
         <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
         <carbon.coordination.version>2.0.7</carbon.coordination.version>
         <!--Dashboard-->
-        <carbon.dashboards.version>4.0.0.alpha3</carbon.dashboards.version>
+        <carbon.dashboards.version>4.0.0.alpha4</carbon.dashboards.version>
         <carbon.uis.version>0.10.4</carbon.uis.version>
 
         <!-- json dependencies -->


### PR DESCRIPTION
## Purpose
This PR bumps the carbon-dashboards version to 4.0.0.alpha4 and add dependencies for common permission provider module.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes