### PR TITLE
RabbitMQ sample consumer 

### DIFF
--- a/modules/samples/sample-clients/pom.xml
+++ b/modules/samples/sample-clients/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.sp</groupId>
         <artifactId>org.wso2.carbon.sp.parent</artifactId>
-        <version>4.0.0-beta2-SNAPSHOT</version>
+        <version>4.0.0-beta3-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/samples/sample-clients/rabbitmq-consumer/build.xml
+++ b/modules/samples/sample-clients/rabbitmq-consumer/build.xml
@@ -22,7 +22,7 @@
     <property name="src.dir" value="src/main/java"/>
     <property name="temp.dir" value="temp"/>
     <property name="class.dir" value="${temp.dir}/classes"/>
-    <property name="main-class" value="org.wso2.sp.sample.rabbitmq.consumer.RabbitmqReceiver"/>
+    <property name="main-class" value="org.wso2.sp.sample.rabbitmq.consumer.RabbitMQReceiver"/>
     <property name="lib.dir" value="${carbon.home}/lib"/>
 
 

--- a/modules/samples/sample-clients/rabbitmq-consumer/build.xml
+++ b/modules/samples/sample-clients/rabbitmq-consumer/build.xml
@@ -26,9 +26,9 @@
     <property name="lib.dir" value="${carbon.home}/lib"/>
 
 
-    <property name="broker" value=""/>
-    <property name="topicName" value="&quot;&quot;"/>
-    <property name="queue" value="&quot;&quot;"/>
+    <property name="uri" value="amqp://guest:guest@localhost:5672"/>
+    <property name="exchange" value="RABBITMQSAMPLE"/>
+    <property name="type" value="xml"/>
 
     <path id="javac.classpath">
         <pathelement path="${class.dir}"/>
@@ -70,12 +70,12 @@
     </target>
 
     <target name="run" depends="compile">
-        <!--<echo>Configure -Dbroker and (-DtopicName=xxxx or -DqueueName)</echo>-->
+        <echo>Publishing events to RabbitMQ endpoints to port 5672</echo>
         <java classname="${main-class}"
               classpathref="javac.classpath" fork="true">
-            <arg value="${broker}"/>
-            <!--<arg value="${topicName}"/>-->
-            <!--<arg value="${queue}"/>-->
+            <arg value="${uri}"/>
+            <arg value="${exchange}"/>
+            <arg value="${type}"/>
         </java>
     </target>
 

--- a/modules/samples/sample-clients/rabbitmq-consumer/build.xml
+++ b/modules/samples/sample-clients/rabbitmq-consumer/build.xml
@@ -71,6 +71,7 @@
 
     <target name="run" depends="compile">
         <echo>Publishing events to RabbitMQ endpoints to port 5672</echo>
+        <echo>Configure -Duri=http://amqp://guest:guest@localhost:5672 -Dexchange=RABBITMQSAMPLE and -Dtype=xml</echo>
         <java classname="${main-class}"
               classpathref="javac.classpath" fork="true">
             <arg value="${uri}"/>

--- a/modules/samples/sample-clients/rabbitmq-consumer/build.xml
+++ b/modules/samples/sample-clients/rabbitmq-consumer/build.xml
@@ -1,0 +1,82 @@
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project default="run">
+
+    <property name="carbon.home" value="../../../"/>
+    <property name="src.dir" value="src/main/java"/>
+    <property name="temp.dir" value="temp"/>
+    <property name="class.dir" value="${temp.dir}/classes"/>
+    <property name="main-class" value="org.wso2.sp.sample.rabbitmq.consumer.RabbitmqReceiver"/>
+    <property name="lib.dir" value="${carbon.home}/lib"/>
+
+
+    <property name="broker" value=""/>
+    <property name="topicName" value="&quot;&quot;"/>
+    <property name="queue" value="&quot;&quot;"/>
+
+    <path id="javac.classpath">
+        <pathelement path="${class.dir}"/>
+        <fileset dir="${lib.dir}">
+            <include name="siddhi-*.jar"/>
+        </fileset>
+        <fileset dir="${carbon.home}/wso2/lib/plugins">
+            <include name="org.apache.commons.logging_*.jar"/>
+            <include name="slf4j.log4j*.jar"/>
+            <include name="org.ops4j.*.jar"/>
+            <include name="slf4j.api_*.jar"/>
+            <include name="siddhi-*.jar"/>
+            <include name="disruptor_*.jar"/>
+            <include name="org.eclipse.osgi_*.jar"/>
+            <include name="quartz_*.jar"/>
+            <include name="antlr4-runtime_*.jar"/>
+            <include name="io.dropwizard.metrics.core_*.jar"/>
+            <include name="com.google.*.jar"/>
+            <include name="org.apache.ws.commons.axiom.axiom-api_*.jar"/>
+            <include name="jaxen_*.jar"/>
+        </fileset>
+    </path>
+
+    <target name="clean">
+        <delete dir="${class.dir}" quiet="true"/>
+        <delete dir="${temp.dir}"/>
+    </target>
+
+    <target name="init">
+        <mkdir dir="${temp.dir}"/>
+        <mkdir dir="${class.dir}"/>
+    </target>
+
+    <target name="compile" depends="init">
+        <javac srcdir="${src.dir}" destdir="${class.dir}" compiler="modern">
+            <include name="*/**"/>
+            <classpath refid="javac.classpath"/>
+        </javac>
+    </target>
+
+    <target name="run" depends="compile">
+        <!--<echo>Configure -Dbroker and (-DtopicName=xxxx or -DqueueName)</echo>-->
+        <java classname="${main-class}"
+              classpathref="javac.classpath" fork="true">
+            <arg value="${broker}"/>
+            <!--<arg value="${topicName}"/>-->
+            <!--<arg value="${queue}"/>-->
+        </java>
+    </target>
+
+</project>

--- a/modules/samples/sample-clients/rabbitmq-consumer/pom.xml
+++ b/modules/samples/sample-clients/rabbitmq-consumer/pom.xml
@@ -19,25 +19,33 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.wso2.sp</groupId>
-        <artifactId>org.wso2.carbon.sp.parent</artifactId>
+        <artifactId>sample-clients</artifactId>
         <version>4.0.0-beta2-SNAPSHOT</version>
-        <relativePath>../../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <name>WSO2 Stream Processor - Sample Clients</name>
-    <artifactId>sample-clients</artifactId>
+    <name>WSO2 Stream Processor - Sample - RabbitMQ Consumer</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <artifactId>rabbitmq-consumer</artifactId>
     <packaging>pom</packaging>
 
-    <modules>
-        <module>kafka-consumer</module>
-        <module>kafka-producer</module>
-        <module>tcp-client</module>
-        <module>tcp-server</module>
-        <module>http-server</module>
-        <module>http-client</module>
-        <module>wso2event-client</module>
-        <module>wso2event-server</module>
-        <module>rabbitmq-consumer</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.siddhi</groupId>
+            <artifactId>siddhi-core</artifactId>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/modules/samples/sample-clients/rabbitmq-consumer/pom.xml
+++ b/modules/samples/sample-clients/rabbitmq-consumer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.sp</groupId>
         <artifactId>sample-clients</artifactId>
-        <version>4.0.0-beta2-SNAPSHOT</version>
+        <version>4.0.0-beta3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/modules/samples/sample-clients/rabbitmq-consumer/pom.xml
+++ b/modules/samples/sample-clients/rabbitmq-consumer/pom.xml
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <!--
-  ~  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
-  ~  WSO2 Inc. licenses this file to you under the Apache License,
-  ~  Version 2.0 (the "License"); you may not use this file except
-  ~  in compliance with the License.
-  ~  You may obtain a copy of the License at
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~  Unless required by applicable law or agreed to in writing,
-  ~  software distributed under the License is distributed on an
-  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~  KIND, either express or implied.  See the License for the
-  ~  specific language governing permissions and limitations
-  ~  under the License.
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>

--- a/modules/samples/sample-clients/rabbitmq-consumer/src/main/java/org/wso2/sp/sample/rabbitmq/consumer/RabbitMQReceiver.java
+++ b/modules/samples/sample-clients/rabbitmq-consumer/src/main/java/org/wso2/sp/sample/rabbitmq/consumer/RabbitMQReceiver.java
@@ -37,11 +37,13 @@ public class RabbitMQReceiver {
     public static void main(String[] args) {
         log.info("Initialize rabbitmq receiver.");
         SiddhiManager siddhiManager = new SiddhiManager();
+        String uri = args[0];
+        String exchange = args[1];
+        String type = args[2];
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(
-                "@App:name(\"RabbitmqInXmlReceiver\")\n" +
-                        "@source(type ='rabbitmq', uri = 'amqp://guest:guest@localhost:5672', " +
-                        "exchange.name = 'RABBITMQSAMPLE',\n" +
-                        "@map(type='xml'))\n" +
+                "@App:name(\"PublishRabbitmqInXmlFormatTest\")\n" +
+                        "@source(type ='rabbitmq',uri = '" + uri + "', exchange.name = '" + exchange + "'," +
+                        "@map(type='" + type + "'))" +
                         "define stream LowProducitonAlertStream (name string, amount double);\n" +
                         "@sink(type='log')\n" +
                         "define stream logStream(name string, amount double);\n" +

--- a/modules/samples/sample-clients/rabbitmq-consumer/src/main/java/org/wso2/sp/sample/rabbitmq/consumer/RabbitMQReceiver.java
+++ b/modules/samples/sample-clients/rabbitmq-consumer/src/main/java/org/wso2/sp/sample/rabbitmq/consumer/RabbitMQReceiver.java
@@ -41,7 +41,7 @@ public class RabbitMQReceiver {
         String exchange = args[1];
         String type = args[2];
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(
-                "@App:name(\"PublishRabbitmqInXmlFormatTest\")\n" +
+                "@App:name(\"RabbitmqSample\")\n" +
                         "@source(type ='rabbitmq',uri = '" + uri + "', exchange.name = '" + exchange + "'," +
                         "@map(type='" + type + "'))" +
                         "define stream LowProducitonAlertStream (name string, amount double);\n" +

--- a/modules/samples/sample-clients/rabbitmq-consumer/src/main/java/org/wso2/sp/sample/rabbitmq/consumer/RabbitMQReceiver.java
+++ b/modules/samples/sample-clients/rabbitmq-consumer/src/main/java/org/wso2/sp/sample/rabbitmq/consumer/RabbitMQReceiver.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.sp.sample.rabbitmq.consumer;
+
+import org.apache.log4j.Logger;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+
+/**
+ * Test client for RabbitMQ source.
+ */
+public class RabbitMQReceiver {
+    private static final Logger log = Logger.getLogger(RabbitMQReceiver.class);
+
+    /**
+     * Main method to start the test client.
+     *
+     * @param args no args need to be provided
+     */
+    public static void main(String[] args) {
+        log.info("Initialize rabbitmq receiver.");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(
+                "@App:name(\"PublishRabbitmqInXmlFormatTest\")\n" +
+                        "@source(type ='rabbitmq', uri = 'amqp://guest:guest@localhost:5672', " +
+                        "exchange.name = 'RABBITMQSAMPLE',\n" +
+                        "@map(type='xml'))\n" +
+                        "define stream LowProducitonAlertStream (name string, amount double);\n" +
+                        "@sink(type='log')\n" +
+                        "define stream logStream(name string, amount double);\n" +
+                        "from LowProducitonAlertStream\n" +
+                        "select * \n" +
+                        "insert into logStream;");
+        siddhiAppRuntime.start();
+        while (true) {
+        }
+    }
+}

--- a/modules/samples/sample-clients/rabbitmq-consumer/src/main/java/org/wso2/sp/sample/rabbitmq/consumer/RabbitMQReceiver.java
+++ b/modules/samples/sample-clients/rabbitmq-consumer/src/main/java/org/wso2/sp/sample/rabbitmq/consumer/RabbitMQReceiver.java
@@ -38,7 +38,7 @@ public class RabbitMQReceiver {
         log.info("Initialize rabbitmq receiver.");
         SiddhiManager siddhiManager = new SiddhiManager();
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(
-                "@App:name(\"PublishRabbitmqInXmlFormatTest\")\n" +
+                "@App:name(\"RabbitmqInXmlReceiver\")\n" +
                         "@source(type ='rabbitmq', uri = 'amqp://guest:guest@localhost:5672', " +
                         "exchange.name = 'RABBITMQSAMPLE',\n" +
                         "@map(type='xml'))\n" +


### PR DESCRIPTION
## Purpose
> To demonstrates how to configure WSO2 Stream Processor to send events via RabbitMQ transport in xml format using mapping,and view the output on the rabbitmq-consumer. But the rabbitmq-consumer is not available in sample-clients of product-sp.
 And also user can override non-optional properties( uri, exchange.name and type of mapping).
## Learning
> Existing clients in product-sp