### PR TITLE
Add fix for path issue in Windows, fixes #219

### DIFF
--- a/modules/distribution/carbon-home/bin/carbon.bat
+++ b/modules/distribution/carbon-home/bin/carbon.bat
@@ -52,6 +52,7 @@ if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
 
 rem ----- Only set RUNTIME_HOME if not already set ----------------------------
 :setRuntimeHome
+setlocal
 if "%RUNTIME_HOME%"=="" set RUNTIME_HOME=%~sdp0..
 rem --- derive RUNTIME NAME from the RUNTIME_HOME path.
 cd /d %RUNTIME_HOME%

--- a/modules/distribution/carbon-home/bin/dashboard/carbon.bat
+++ b/modules/distribution/carbon-home/bin/dashboard/carbon.bat
@@ -52,6 +52,7 @@ if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
 
 rem ----- Only set RUNTIME_HOME if not already set ----------------------------
 :setRuntimeHome
+setlocal
 if "%RUNTIME_HOME%"=="" set RUNTIME_HOME=%~sdp0..
 rem --- derive RUNTIME NAME from the RUNTIME_HOME path.
 cd /d %RUNTIME_HOME%

--- a/modules/distribution/carbon-home/bin/editor/carbon.bat
+++ b/modules/distribution/carbon-home/bin/editor/carbon.bat
@@ -52,6 +52,7 @@ if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
 
 rem ----- Only set RUNTIME_HOME if not already set ----------------------------
 :setRuntimeHome
+setlocal
 if "%RUNTIME_HOME%"=="" set RUNTIME_HOME=%~sdp0..
 rem --- derive RUNTIME NAME from the RUNTIME_HOME path.
 cd /d %RUNTIME_HOME%

--- a/modules/distribution/carbon-home/bin/manager/carbon.bat
+++ b/modules/distribution/carbon-home/bin/manager/carbon.bat
@@ -52,6 +52,7 @@ if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
 
 rem ----- Only set RUNTIME_HOME if not already set ----------------------------
 :setRuntimeHome
+setlocal
 if "%RUNTIME_HOME%"=="" set RUNTIME_HOME=%~sdp0..
 rem --- derive RUNTIME NAME from the RUNTIME_HOME path.
 cd /d %RUNTIME_HOME%

--- a/modules/distribution/carbon-home/bin/worker/carbon.bat
+++ b/modules/distribution/carbon-home/bin/worker/carbon.bat
@@ -52,6 +52,7 @@ if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
 
 rem ----- Only set RUNTIME_HOME if not already set ----------------------------
 :setRuntimeHome
+setlocal
 if "%RUNTIME_HOME%"=="" set RUNTIME_HOME=%~sdp0..
 rem --- derive RUNTIME NAME from the RUNTIME_HOME path.
 cd /d %RUNTIME_HOME%


### PR DESCRIPTION
## Purpose
Fixes #219 

## Goals
Prevent global setting of environment variables

## Approach
Enables the path and runtime environment variables to be set locally, so that the implicit `endlocal` call will clear them upon exit.