### PR TITLE
Used owsap feature in distribution + version upgrades

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -314,6 +314,12 @@
             <artifactId>org.wso2.carbon.data.provider.feature</artifactId>
             <type>zip</type>
         </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.orbit.org.owasp.encoder.feature</artifactId>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -835,6 +841,11 @@
                                     <id>org.wso2.carbon.data.provider.feature</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
+
+                                <feature>
+                                    <id>org.wso2.orbit.org.owasp.encoder.feature</id>
+                                    <version>${carbon.analytics-common.version}</version>
+                                </feature>
                             </features>
                         </configuration>
                     </execution>
@@ -988,11 +999,11 @@
                                     <version>${carbon.metrics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.stream.processor.statistics.feature</id>
+                                    <id>org.wso2.carbon.stream.processor.statistics.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.siddhi.metrics.core.feature</id>
+                                    <id>org.wso2.carbon.siddhi.metrics.core.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <!-- MSF4J Features -->
@@ -1003,51 +1014,51 @@
 
                                 <!-- Stream Processor Features -->
                                 <feature>
-                                    <id>org.wso2.carbon.stream.processor.core.feature</id>
+                                    <id>org.wso2.carbon.stream.processor.core.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.stream.processor.common.feature</id>
+                                    <id>org.wso2.carbon.stream.processor.common.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.event.simulator.core.feature</id>
+                                    <id>org.wso2.carbon.event.simulator.core.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.siddhi.feature</id>
+                                    <id>org.wso2.siddhi.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.siddhi.store.api.rest.feature</id>
+                                    <id>org.wso2.carbon.siddhi.store.api.rest.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
 
                                 <!-- Authentication feature -->
                                 <feature>
-                                    <id>org.wso2.carbon.analytics.msf4j.interceptor.common.feature</id>
+                                    <id>org.wso2.carbon.analytics.msf4j.interceptor.common.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.analytics.idp.client.feature</id>
+                                    <id>org.wso2.carbon.analytics.idp.client.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
 
                                 <!-- Databridge feature -->
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.feature</id>
+                                    <id>org.wso2.carbon.databridge.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.agent.feature</id>
+                                    <id>org.wso2.carbon.databridge.agent.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.commons.thrift.feature</id>
+                                    <id>org.wso2.carbon.databridge.commons.thrift.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.commons.feature</id>
+                                    <id>org.wso2.carbon.databridge.commons.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
 
@@ -1069,6 +1080,11 @@
                                 <feature>
                                     <id>org.wso2.carbon.sp.distributed.resource.core.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
+                                </feature>
+
+                                <feature>
+                                    <id>org.wso2.orbit.org.owasp.encoder.feature.group</id>
+                                    <version>${carbon.analytics-common.version}</version>
                                 </feature>
                             </features>
                         </configuration>
@@ -1168,11 +1184,11 @@
                                     <version>${carbon.metrics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.stream.processor.statistics.feature</id>
+                                    <id>org.wso2.carbon.stream.processor.statistics.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.siddhi.metrics.core.feature</id>
+                                    <id>org.wso2.carbon.siddhi.metrics.core.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <!-- MSF4J Features -->
@@ -1183,29 +1199,29 @@
 
                                 <!-- Authentication feature -->
                                 <feature>
-                                    <id>org.wso2.carbon.analytics.idp.client.feature</id>
+                                    <id>org.wso2.carbon.analytics.idp.client.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.analytics.msf4j.interceptor.common.feature</id>
+                                    <id>org.wso2.carbon.analytics.msf4j.interceptor.common.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
 
                                 <!-- Databridge feature -->
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.feature</id>
+                                    <id>org.wso2.carbon.databridge.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.agent.feature</id>
+                                    <id>org.wso2.carbon.databridge.agent.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.commons.thrift.feature</id>
+                                    <id>org.wso2.carbon.databridge.commons.thrift.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.commons.feature</id>
+                                    <id>org.wso2.carbon.databridge.commons.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
 
@@ -1229,6 +1245,10 @@
                                     <version>${carbon.coordination.version}</version>
                                 </feature>
 
+                                <feature>
+                                    <id>org.wso2.orbit.org.owasp.encoder.feature.group</id>
+                                    <version>${carbon.analytics-common.version}</version>
+                                </feature>
                             </features>
                         </configuration>
                     </execution>
@@ -1313,11 +1333,11 @@
                                     <version>${carbon.metrics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.stream.processor.statistics.feature</id>
+                                    <id>org.wso2.carbon.stream.processor.statistics.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.siddhi.metrics.core.feature</id>
+                                    <id>org.wso2.carbon.siddhi.metrics.core.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <!-- MSF4J Features -->
@@ -1328,71 +1348,71 @@
 
                                 <!-- Authentication feature -->
                                 <feature>
-                                    <id>org.wso2.carbon.analytics.msf4j.interceptor.common.feature</id>
+                                    <id>org.wso2.carbon.analytics.msf4j.interceptor.common.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.analytics.idp.client.feature</id>
+                                    <id>org.wso2.carbon.analytics.idp.client.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
 
                                 <!-- Stream Processor Features -->
                                 <feature>
-                                    <id>org.wso2.carbon.stream.processor.core.feature</id>
+                                    <id>org.wso2.carbon.stream.processor.core.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.stream.processor.common.feature</id>
+                                    <id>org.wso2.carbon.stream.processor.common.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.siddhi.editor.core.feature</id>
+                                    <id>org.wso2.carbon.siddhi.editor.core.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.siddhi.feature</id>
+                                    <id>org.wso2.siddhi.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.siddhi.store.api.rest.feature</id>
+                                    <id>org.wso2.carbon.siddhi.store.api.rest.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
 
                                 <!--simulator feature-->
                                 <feature>
-                                    <id>org.wso2.carbon.event.simulator.core.feature</id>
+                                    <id>org.wso2.carbon.event.simulator.core.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
 
                                 <!-- Databridge feature -->
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.feature</id>
+                                    <id>org.wso2.carbon.databridge.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.agent.feature</id>
+                                    <id>org.wso2.carbon.databridge.agent.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.commons.thrift.feature</id>
+                                    <id>org.wso2.carbon.databridge.commons.thrift.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.commons.feature</id>
+                                    <id>org.wso2.carbon.databridge.commons.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
 
                                 <!-- Clustering -->
                                 <feature>
-                                    <id>org.wso2.carbon.cluster.coordinator.service.feature</id>
+                                    <id>org.wso2.carbon.cluster.coordinator.service.feature.group</id>
                                     <version>${carbon.coordination.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.cluster.coordinator.commons.feature</id>
+                                    <id>org.wso2.carbon.cluster.coordinator.commons.feature.group</id>
                                     <version>${carbon.coordination.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.cluster.coordinator.rdbms.feature</id>
+                                    <id>org.wso2.carbon.cluster.coordinator.rdbms.feature.group</id>
                                     <version>${carbon.coordination.version}</version>
                                 </feature>
 
@@ -1400,6 +1420,11 @@
                                 <feature>
                                     <id>org.wso2.carbon.sp.distributed.resource.core.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
+                                </feature>
+
+                                <feature>
+                                    <id>org.wso2.orbit.org.owasp.encoder.feature.group</id>
+                                    <version>${carbon.analytics-common.version}</version>
                                 </feature>
                             </features>
                         </configuration>
@@ -1449,131 +1474,136 @@
                                 </feature>
                                 <!--Transport-->
                                 <feature>
-                                    <id>org.wso2.carbon.messaging.feature</id>
+                                    <id>org.wso2.carbon.messaging.feature.group</id>
                                     <version>${carbon.messaging.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.transport.http.netty.feature</id>
+                                    <id>org.wso2.carbon.transport.http.netty.feature.group</id>
                                     <version>${org.wso2.carbon.transport.http.netty.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.connector.framework.feature</id>
+                                    <id>org.wso2.carbon.connector.framework.feature.group</id>
                                     <version>${org.wso2.carbon.transport.version}</version>
                                 </feature>
                                 <!--Deployment-->
                                 <feature>
-                                    <id>org.wso2.carbon.deployment.engine.feature</id>
+                                    <id>org.wso2.carbon.deployment.engine.feature.group</id>
                                     <version>${carbon.deployment.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.deployment.notifier.feature</id>
+                                    <id>org.wso2.carbon.deployment.notifier.feature.group</id>
                                     <version>${carbon.deployment.version}</version>
                                 </feature>
                                 <!--MSF4J-->
                                 <feature>
-                                    <id>org.wso2.msf4j.feature</id>
+                                    <id>org.wso2.msf4j.feature.group</id>
                                     <version>${msf4j.version}</version>
                                 </feature>
                                 <!--Metrics-->
                                 <feature>
-                                    <id>org.wso2.carbon.metrics.core.feature</id>
+                                    <id>org.wso2.carbon.metrics.core.feature.group</id>
                                     <version>${carbon.metrics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.metrics.jdbc.core.feature</id>
+                                    <id>org.wso2.carbon.metrics.jdbc.core.feature.group</id>
                                     <version>${carbon.metrics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.metrics.das.core.feature</id>
+                                    <id>org.wso2.carbon.metrics.das.core.feature.group</id>
                                     <version>${carbon.metrics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.jndi.feature</id>
+                                    <id>org.wso2.carbon.jndi.feature.group</id>
                                     <version>${carbon.jndi.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.datasource.core.feature</id>
+                                    <id>org.wso2.carbon.datasource.core.feature.group</id>
                                     <version>${carbon.datasources.version}</version>
                                 </feature>
                                 <!--Dashboard-->
                                 <feature>
-                                    <id>org.wso2.carbon.dashboards.api.feature</id>
+                                    <id>org.wso2.carbon.dashboards.api.feature.group</id>
                                     <version>${carbon.dashboards.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.dashboards.portal.feature</id>
+                                    <id>org.wso2.carbon.dashboards.portal.feature.group</id>
                                     <version>${carbon.dashboards.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.dashboards.samples.feature</id>
+                                    <id>org.wso2.carbon.dashboards.samples.feature.group</id>
                                     <version>${carbon.dashboards.version}</version>
                                 </feature>
                                 <!--Status Dahsboard-->
                                 <feature>
-                                    <id>org.wso2.carbon.status.dashboard.core.feature</id>
+                                    <id>org.wso2.carbon.status.dashboard.core.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.status.dashboard.web.feature</id>
+                                    <id>org.wso2.carbon.status.dashboard.web.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <!--Carbon UI Server-->
                                 <feature>
-                                    <id>org.wso2.carbon.uis.feature</id>
+                                    <id>org.wso2.carbon.uis.feature.group</id>
                                     <version>${carbon.uis.version}</version>
                                 </feature>
 
                                 <!-- Authentication feature -->
                                 <feature>
-                                    <id>org.wso2.carbon.analytics.idp.client.feature</id>
+                                    <id>org.wso2.carbon.analytics.idp.client.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.analytics.msf4j.interceptor.common.feature</id>
+                                    <id>org.wso2.carbon.analytics.msf4j.interceptor.common.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.analytics.auth.rest.api.feature</id>
+                                    <id>org.wso2.carbon.analytics.auth.rest.api.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
 
                                 <!-- Permission module -->
                                 <feature>
-                                    <id>org.wso2.carbon.analytics.permissions.feature</id>
+                                    <id>org.wso2.carbon.analytics.permissions.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
 
                                 <!-- Databridge feature -->
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.feature</id>
+                                    <id>org.wso2.carbon.databridge.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.agent.feature</id>
+                                    <id>org.wso2.carbon.databridge.agent.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.commons.thrift.feature</id>
+                                    <id>org.wso2.carbon.databridge.commons.thrift.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.databridge.commons.feature</id>
+                                    <id>org.wso2.carbon.databridge.commons.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
 
                                 <!-- Business rules -->
                                 <feature>
-                                    <id>org.wso2.carbon.business.rules.core.feature</id>
+                                    <id>org.wso2.carbon.business.rules.core.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.business.rules.web.feature</id>
+                                    <id>org.wso2.carbon.business.rules.web.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
 
                                 <!-- Data Provider feature -->
                                 <feature>
-                                    <id>org.wso2.carbon.data.provider.feature</id>
+                                    <id>org.wso2.carbon.data.provider.feature.group</id>
+                                    <version>${carbon.analytics-common.version}</version>
+                                </feature>
+
+                                <feature>
+                                    <id>org.wso2.orbit.org.owasp.encoder.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
                                 </feature>
                             </features>

--- a/pom.xml
+++ b/pom.xml
@@ -745,6 +745,12 @@
                 <version>${carbon.analytics.version}</version>
                 <type>zip</type>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.analytics-common</groupId>
+                <artifactId>org.wso2.orbit.org.owasp.encoder.feature</artifactId>
+                <version>${carbon.analytics-common.version}</version>
+                <type>zip</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -840,8 +846,8 @@
     </build>
 
     <properties>
-        <carbon.analytics.version>2.0.182</carbon.analytics.version>
-        <siddhi.version>4.0.0-beta10</siddhi.version>
+        <carbon.analytics.version>2.0.195</carbon.analytics.version>
+        <siddhi.version>4.0.0-beta15</siddhi.version>
 
         <!-- Maven plugins -->
         <!--Bundle Plugin - Overridden from parent due to a bug in latest version related to capability providers-->
@@ -888,7 +894,7 @@
         <carbon.config.version.range>[2.1.0, 3.0.0)</carbon.config.version.range>
         <carbon.securevault.version>5.0.10</carbon.securevault.version>
 
-        <carbon.analytics-common.version>6.0.22</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.0.29</carbon.analytics-common.version>
 
         <slf4j.version>1.7.5</slf4j.version>
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)


### PR DESCRIPTION
## Purpose
> Pack the owsap dependency with distribution

## Approach
> Pack the owsap feature in all runtimes
> Use feature.group to conform with standard when packing features in runtimes
> Bump Siddhi to beta15
> Bump carbon analytics common to 6.0.29
> Bump carbon analytics to 2.0.195
