### PR TITLE
added fix for restricting only localhost/127.0.0.1 to be worked on ed…

### DIFF
--- a/modules/distribution/carbon-home/conf/editor/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/editor/deployment.yaml
@@ -40,7 +40,7 @@ wso2.transport.http:
   listenerConfigurations:
     -
       id: "default"
-      host: "0.0.0.0"
+      host: "127.0.0.1"
       port: 9390
     -
       id: "msf4j-https"


### PR DESCRIPTION

## Purpose
Allow editor to be worked on localhost

## Goals
provide better security 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
