### PR TITLE
Bump MSF4J version to v2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -924,7 +924,7 @@
         <common.collections4.version>4.0</common.collections4.version>
 
         <!--MSF4J related-->
-        <msf4j.version>2.5.0</msf4j.version>
+        <msf4j.version>2.5.1</msf4j.version>
         <com.fasterxml.jackson.core.version>2.7.4</com.fasterxml.jackson.core.version>
         <io.swagger.version>1.5.10</io.swagger.version>
         <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>


### PR DESCRIPTION
## Purpose
- Bumps MSF4J version to v2.5.1
- Fixes #331 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
