### PR TITLE
Bump msf4j, carbon-analytics-common, carbon-dashboard versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -923,7 +923,7 @@
         <common.collections4.version>4.0</common.collections4.version>
 
         <!--MSF4J related-->
-        <msf4j.version>2.5.1</msf4j.version>
+        <msf4j.version>2.5.2</msf4j.version>
         <com.fasterxml.jackson.core.version>2.7.4</com.fasterxml.jackson.core.version>
         <io.swagger.version>1.5.10</io.swagger.version>
         <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -833,7 +833,7 @@
     <properties>
         <carbon.analytics.version>2.0.244</carbon.analytics.version>
         <siddhi.version>4.0.5</siddhi.version>
-        <carbon.analytics-common.version>6.0.49</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.0.51</carbon.analytics-common.version>
       
         <!-- Maven plugins -->
         <!--Bundle Plugin - Overridden from parent due to a bug in latest version related to capability providers-->

--- a/pom.xml
+++ b/pom.xml
@@ -878,7 +878,7 @@
 
         <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
         <!--Dashboard-->
-        <carbon.dashboards.version>4.0.6</carbon.dashboards.version>
+        <carbon.dashboards.version>4.0.7</carbon.dashboards.version>
         <carbon.uis.version>0.19.2</carbon.uis.version>
 
         <!-- json dependencies -->


### PR DESCRIPTION
## Purpose
- bump msf4j to v2.5.2
- bump carbon-analytics-common version to v6.0.51
- bump carbon-dashboards version to v4.0.7

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
