### PR TITLE
Bumping Carbon Dashboards version to 4.0.8

### DIFF
--- a/modules/distribution/carbon-home/LICENSE.txt
+++ b/modules/distribution/carbon-home/LICENSE.txt
@@ -117,9 +117,9 @@ org.wso2.carbon.cluster.coordinator.rdbms_2.0.12.jar                            
 org.wso2.carbon.cluster.coordinator.service_2.0.12.jar                          bundle         apache2   14634
 org.wso2.carbon.config_2.1.5.jar                                                bundle         apache2   14633
 org.wso2.carbon.core_5.2.6.jar                                                  bundle         apache2   14632
-org.wso2.carbon.dashboards.api_4.0.7.jar                                        bundle         apache2   14836
-org.wso2.carbon.dashboards.core_4.0.7.jar                                       bundle         apache2   14835
-org.wso2.carbon.dashboards.samples.endpoint_4.0.7.jar                           bundle         apache2   14834
+org.wso2.carbon.dashboards.api_4.0.8.jar                                        bundle         apache2   14836
+org.wso2.carbon.dashboards.core_4.0.8.jar                                       bundle         apache2   14835
+org.wso2.carbon.dashboards.samples.endpoint_4.0.8.jar                           bundle         apache2   14834
 org.wso2.carbon.data.provider_2.0.248.jar                                       bundle         apache2   14833
 org.wso2.carbon.database.query.manager_6.0.51.jar                               bundle         apache2   14832
 org.wso2.carbon.databridge.agent_6.0.51.jar                                     bundle         apache2   14831

--- a/pom.xml
+++ b/pom.xml
@@ -878,7 +878,7 @@
 
         <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
         <!--Dashboard-->
-        <carbon.dashboards.version>4.0.7</carbon.dashboards.version>
+        <carbon.dashboards.version>4.0.8</carbon.dashboards.version>
         <carbon.uis.version>0.19.2</carbon.uis.version>
 
         <!-- json dependencies -->


### PR DESCRIPTION
## Purpose
Bump carbon dashboards version to 4.0.8 and update license file for dashboard jars