### PR TITLE
Add missing datasource conf in manager runtime and Upgrade carbon-coordination and analytics version

### DIFF
--- a/modules/distribution/carbon-home/conf/manager/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/manager/deployment.yaml
@@ -268,6 +268,24 @@ wso2.datasources:
         validationTimeout: 30000
         isAutoCommit: false
 
+  - name: WSO2_STATUS_DASHBOARD_DISTRIBUTED_DB
+    description: The datasource used for distributed status dashboard feature
+    jndiConfig:
+      name: jdbc/WSO2_STATUS_DASHBOARD_DISTRIBUTED_DB
+      useJndiReference: true
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_STATUS_DASHBOARD_DISTRIBUTED_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+
   # Cluster Configuration
 cluster.config:
   enabled: false

--- a/pom.xml
+++ b/pom.xml
@@ -870,7 +870,7 @@
 
     <properties>
 
-        <carbon.analytics.version>2.0.290</carbon.analytics.version>
+        <carbon.analytics.version>2.0.294</carbon.analytics.version>
         <siddhi.version>4.1.7</siddhi.version>
 
         <carbon.analytics-common.version>6.0.55</carbon.analytics-common.version>
@@ -1031,7 +1031,7 @@
 
         <siddhi.script.js.version>4.0.8</siddhi.script.js.version>
 
-        <carbon.coordination.version>2.0.12</carbon.coordination.version>
+        <carbon.coordination.version>2.0.14</carbon.coordination.version>
 
         <!--Integration Test Framework Versions -->
         <testng.version>6.9.10</testng.version>


### PR DESCRIPTION
## Purpose
Upgrade analytics and coordination version for weekly release 
Add missing data source conf for manager runtime

## Goals
Upgrade analytics and coordination version for weekly release 
Add missing data source conf for manager runtime

## Approach
Upgrade analytics and coordination version for weekly release 
Add missing data source conf for manager runtime

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Marketing
NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
java version "1.8.0_161"
Java(TM) SE Runtime Environment (build 1.8.0_161-b12)
Java HotSpot(TM) 64-Bit Server VM (build 25.161-b12, mixed mode)
 
## Learning
NA