### PR TITLE
Add SQS Source extension

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -626,6 +626,12 @@
                                     <version>${siddhi.store.redis.version}</version>
                                     <type>jar</type>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wso2.extension.siddhi.io.sqs</groupId>
+                                    <artifactId>siddhi-io-sqs</artifactId>
+                                    <version>${siddhi.io.sqs.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
                             </artifactItems>
                             <outputDirectory>${project.build.directory}/extensions</outputDirectory>
                             <overWriteReleases>false</overWriteReleases>

--- a/pom.xml
+++ b/pom.xml
@@ -750,6 +750,11 @@
                 <version>${siddhi.io.twitter.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.extension.siddhi.io.sqs</groupId>
+                <artifactId>siddhi-io-sqs</artifactId>
+                <version>${siddhi.io.sqs.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.extension.siddhi.map.json</groupId>
                 <artifactId>siddhi-map-json</artifactId>
                 <version>${siddhi.map.json.version}</version>
@@ -1021,6 +1026,7 @@
         <siddhi.io.wso2event.version>4.0.12</siddhi.io.wso2event.version>
         <siddhi.io.http.version>1.0.18</siddhi.io.http.version>
         <siddhi.io.twitter.version>1.0.4</siddhi.io.twitter.version>
+        <siddhi.io.sqs.version>1.0.0</siddhi.io.sqs.version>
 
         <siddhi.map.json.version>4.0.18</siddhi.map.json.version>
         <siddhi.map.wso2event.version>4.0.10</siddhi.map.wso2event.version>


### PR DESCRIPTION
## Purpose
Adding SQS IO extension to the product.

## Goals
This extension allows a user to define a source/sink to consume/publish messages from/to a AWS SQS Queue.

## User stories
https://docs.google.com/document/d/168kc6rESZvsUWecoW01AomdS6B-JE0d9ks4ADei2-L0/edit?usp=sharing

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK v1.8.0_161
