### PR TITLE
Update manager runtime configs. Bump carbon-coordination versions

### DIFF
--- a/modules/distribution/carbon-home/conf/manager/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/manager/deployment.yaml
@@ -290,4 +290,7 @@ deployment.config:
   datasource: SP_MGT_DB           # define a mysql datasource in datasources and refer it from here.
   minResourceCount: 1
   bootstrapURLs: localhost:9092   # kafka urls
-  zooKeeperURLs: localhost:2181   # zookeeper urls
+  zooKeeperConfig:
+    zooKeeperURLs: localhost:2181   # zookeeper urls
+    connectionTimeout: 10000
+    sessionTimeout: 10000

--- a/pom.xml
+++ b/pom.xml
@@ -1051,7 +1051,7 @@
 
         <siddhi.script.js.version>4.0.8</siddhi.script.js.version>
 
-        <carbon.coordination.version>2.0.14</carbon.coordination.version>
+        <carbon.coordination.version>2.0.16</carbon.coordination.version>
 
         <!--Integration Test Framework Versions -->
         <testng.version>6.9.10</testng.version>


### PR DESCRIPTION
## Purpose
Update manager runtime with new configs for zookeeper configuration
Bump carbon-coordination to 2.0.16