### PR TITLE
Upgrade carbon-ui-server version to 0.19.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -934,7 +934,7 @@
         <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
         <!--Dashboard-->
         <carbon.dashboards.version>4.0.15</carbon.dashboards.version>
-        <carbon.uis.version>0.19.3</carbon.uis.version>
+        <carbon.uis.version>0.19.5</carbon.uis.version>
 
         <!-- json dependencies -->
         <gson.version>2.8.0</gson.version>


### PR DESCRIPTION
## Purpose
Upgrade carbon-ui-server version to 0.19.5

## Goals
Fix the SP server startup issue due to OSGI capability error.

## Approach
Upgrade carbon-ui-server version to 0.19.5

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Marketing
NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
java version "1.8.0_171"
Java(TM) SE Runtime Environment (build 1.8.0_171-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.171-b11, mixed mode)
Node 8.8.1
 
## Learning
NA