### PR TITLE
Change http listen address to 0.0.0.0 instead of localhost for remote access

### DIFF
--- a/modules/distribution/carbon-home/conf/editor/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/editor/deployment.yaml
@@ -40,7 +40,7 @@ wso2.transport.http:
   listenerConfigurations:
     -
       id: "default"
-      host: "127.0.0.1"
+      host: "0.0.0.0"
       port: 9390
     -
       id: "msf4j-https"


### PR DESCRIPTION
## Purpose
Changing http listen address to 0.0.0.0 instead of localhost for remote access. Since [#1158](https://github.com/wso2/carbon-analytics/issues/1158) [#1207](https://github.com/wso2/carbon-analytics/issues/1207) issues are fixed we can allow remote access to Editor.
