### PR TITLE
Adding org.wso2.sp.solutions.http.analytics.feature

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -307,6 +307,13 @@
             <artifactId>org.wso2.carbon.permissions.rest.api.feature</artifactId>
             <type>zip</type>
         </dependency>
+
+        <!-- Solution Features -->
+        <dependency>
+            <groupId>org.wso2.sp</groupId>
+            <artifactId>org.wso2.sp.solutions.http.analytics.feature</artifactId>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -872,6 +879,12 @@
                                 <feature>
                                     <id>org.wso2.carbon.data.provider.feature</id>
                                     <version>${carbon.analytics.version}</version>
+                                </feature>
+
+                                <!-- Solution Features -->
+                                <feature>
+                                    <id>org.wso2.sp.solutions.http.analytics.feature</id>
+                                    <version>${project.version}</version>
                                 </feature>
                             </features>
                         </configuration>
@@ -1602,6 +1615,12 @@
                                 <feature>
                                     <id>org.wso2.carbon.data.provider.feature.group</id>
                                     <version>${carbon.analytics.version}</version>
+                                </feature>
+
+                                <!-- Solution Features -->
+                                <feature>
+                                    <id>org.wso2.sp.solutions.http.analytics.feature</id>
+                                    <version>${project.version}</version>
                                 </feature>
                             </features>
                         </configuration>

--- a/modules/solutions/http-analytics/features/etc/feature.properties
+++ b/modules/solutions/http-analytics/features/etc/feature.properties
@@ -1,0 +1,200 @@
+#
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+providerName=WSO2 Inc.
+
+########################## license properties ##################################
+licenseURL=http://www.apache.org/licenses/LICENSE-2.0
+
+license=\
+                                 Apache License\n\
+                           Version 2.0, January 2004\n\
+                        http://www.apache.org/licenses/\n\
+\n\
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\
+\n\
+   1. Definitions.\n\
+\n\
+      "License" shall mean the terms and conditions for use, reproduction,\n\
+      and distribution as defined by Sections 1 through 9 of this document.\n\
+\n\
+      "Licensor" shall mean the copyright owner or entity authorized by\n\
+      the copyright owner that is granting the License.\n\
+\n\
+      "Legal Entity" shall mean the union of the acting entity and all\n\
+      other entities that control, are controlled by, or are under common\n\
+      control with that entity. For the purposes of this definition,\n\
+      "control" means (i) the power, direct or indirect, to cause the\n\
+      direction or management of such entity, whether by contract or\n\
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n\
+      outstanding shares, or (iii) beneficial ownership of such entity.\n\
+\n\
+      "You" (or "Your") shall mean an individual or Legal Entity\n\
+      exercising permissions granted by this License.\n\
+\n\
+      "Source" form shall mean the preferred form for making modifications,\n\
+      including but not limited to software source code, documentation\n\
+      source, and configuration files.\n\
+\n\
+      "Object" form shall mean any form resulting from mechanical\n\
+      transformation or translation of a Source form, including but\n\
+      not limited to compiled object code, generated documentation,\n\
+      and conversions to other media types.\n\
+\n\
+      "Work" shall mean the work of authorship, whether in Source or\n\
+      Object form, made available under the License, as indicated by a\n\
+      copyright notice that is included in or attached to the work\n\
+      (an example is provided in the Appendix below).\n\
+\n\
+      "Derivative Works" shall mean any work, whether in Source or Object\n\
+      form, that is based on (or derived from) the Work and for which the\n\
+      editorial revisions, annotations, elaborations, or other modifications\n\
+      represent, as a whole, an original work of authorship. For the purposes\n\
+      of this License, Derivative Works shall not include works that remain\n\
+      separable from, or merely link (or bind by name) to the interfaces of,\n\
+      the Work and Derivative Works thereof.\n\
+\n\
+      "Contribution" shall mean any work of authorship, including\n\
+      the original version of the Work and any modifications or additions\n\
+      to that Work or Derivative Works thereof, that is intentionally\n\
+      submitted to Licensor for inclusion in the Work by the copyright owner\n\
+      or by an individual or Legal Entity authorized to submit on behalf of\n\
+      the copyright owner. For the purposes of this definition, "submitted"\n\
+      means any form of electronic, verbal, or written communication sent\n\
+      to the Licensor or its representatives, including but not limited to\n\
+      communication on electronic mailing lists, source code control systems,\n\
+      and issue tracking systems that are managed by, or on behalf of, the\n\
+      Licensor for the purpose of discussing and improving the Work, but\n\
+      excluding communication that is conspicuously marked or otherwise\n\
+      designated in writing by the copyright owner as "Not a Contribution."\n\
+\n\
+      "Contributor" shall mean Licensor and any individual or Legal Entity\n\
+      on behalf of whom a Contribution has been received by Licensor and\n\
+      subsequently incorporated within the Work.\n\
+\n\
+   2. Grant of Copyright License. Subject to the terms and conditions of\n\
+      this License, each Contributor hereby grants to You a perpetual,\n\
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n\
+      copyright license to reproduce, prepare Derivative Works of,\n\
+      publicly display, publicly perform, sublicense, and distribute the\n\
+      Work and such Derivative Works in Source or Object form.\n\
+\n\
+   3. Grant of Patent License. Subject to the terms and conditions of\n\
+      this License, each Contributor hereby grants to You a perpetual,\n\
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n\
+      (except as stated in this section) patent license to make, have made,\n\
+      use, offer to sell, sell, import, and otherwise transfer the Work,\n\
+      where such license applies only to those patent claims licensable\n\
+      by such Contributor that are necessarily infringed by their\n\
+      Contribution(s) alone or by combination of their Contribution(s)\n\
+      with the Work to which such Contribution(s) was submitted. If You\n\
+      institute patent litigation against any entity (including a\n\
+      cross-claim or counterclaim in a lawsuit) alleging that the Work\n\
+      or a Contribution incorporated within the Work constitutes direct\n\
+      or contributory patent infringement, then any patent licenses\n\
+      granted to You under this License for that Work shall terminate\n\
+      as of the date such litigation is filed.\n\
+\n\
+   4. Redistribution. You may reproduce and distribute copies of the\n\
+      Work or Derivative Works thereof in any medium, with or without\n\
+      modifications, and in Source or Object form, provided that You\n\
+      meet the following conditions:\n\
+\n\
+      (a) You must give any other recipients of the Work or\n\
+          Derivative Works a copy of this License; and\n\
+\n\
+      (b) You must cause any modified files to carry prominent notices\n\
+          stating that You changed the files; and\n\
+\n\
+      (c) You must retain, in the Source form of any Derivative Works\n\
+          that You distribute, all copyright, patent, trademark, and\n\
+          attribution notices from the Source form of the Work,\n\
+          excluding those notices that do not pertain to any part of\n\
+          the Derivative Works; and\n\
+\n\
+      (d) If the Work includes a "NOTICE" text file as part of its\n\
+          distribution, then any Derivative Works that You distribute must\n\
+          include a readable copy of the attribution notices contained\n\
+          within such NOTICE file, excluding those notices that do not\n\
+          pertain to any part of the Derivative Works, in at least one\n\
+          of the following places: within a NOTICE text file distributed\n\
+          as part of the Derivative Works; within the Source form or\n\
+          documentation, if provided along with the Derivative Works; or,\n\
+          within a display generated by the Derivative Works, if and\n\
+          wherever such third-party notices normally appear. The contents\n\
+          of the NOTICE file are for informational purposes only and\n\
+          do not modify the License. You may add Your own attribution\n\
+          notices within Derivative Works that You distribute, alongside\n\
+          or as an addendum to the NOTICE text from the Work, provided\n\
+          that such additional attribution notices cannot be construed\n\
+          as modifying the License.\n\
+\n\
+      You may add Your own copyright statement to Your modifications and\n\
+      may provide additional or different license terms and conditions\n\
+      for use, reproduction, or distribution of Your modifications, or\n\
+      for any such Derivative Works as a whole, provided Your use,\n\
+      reproduction, and distribution of the Work otherwise complies with\n\
+      the conditions stated in this License.\n\
+\n\
+   5. Submission of Contributions. Unless You explicitly state otherwise,\n\
+      any Contribution intentionally submitted for inclusion in the Work\n\
+      by You to the Licensor shall be under the terms and conditions of\n\
+      this License, without any additional terms or conditions.\n\
+      Notwithstanding the above, nothing herein shall supersede or modify\n\
+      the terms of any separate license agreement you may have executed\n\
+      with Licensor regarding such Contributions.\n\
+\n\
+   6. Trademarks. This License does not grant permission to use the trade\n\
+      names, trademarks, service marks, or product names of the Licensor,\n\
+      except as required for reasonable and customary use in describing the\n\
+      origin of the Work and reproducing the content of the NOTICE file.\n\
+\n\
+   7. Disclaimer of Warranty. Unless required by applicable law or\n\
+      agreed to in writing, Licensor provides the Work (and each\n\
+      Contributor provides its Contributions) on an "AS IS" BASIS,\n\
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n\
+      implied, including, without limitation, any warranties or conditions\n\
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n\
+      PARTICULAR PURPOSE. You are solely responsible for determining the\n\
+      appropriateness of using or redistributing the Work and assume any\n\
+      risks associated with Your exercise of permissions under this License.\n\
+\n\
+   8. Limitation of Liability. In no event and under no legal theory,\n\
+      whether in tort (including negligence), contract, or otherwise,\n\
+      unless required by applicable law (such as deliberate and grossly\n\
+      negligent acts) or agreed to in writing, shall any Contributor be\n\
+      liable to You for damages, including any direct, indirect, special,\n\
+      incidental, or consequential damages of any character arising as a\n\
+      result of this License or out of the use or inability to use the\n\
+      Work (including but not limited to damages for loss of goodwill,\n\
+      work stoppage, computer failure or malfunction, or any and all\n\
+      other commercial damages or losses), even if such Contributor\n\
+      has been advised of the possibility of such damages.\n\
+\n\
+   9. Accepting Warranty or Additional Liability. While redistributing\n\
+      the Work or Derivative Works thereof, You may choose to offer,\n\
+      and charge a fee for, acceptance of support, warranty, indemnity,\n\
+      or other liability obligations and/or rights consistent with this\n\
+      License. However, in accepting such obligations, You may act only\n\
+      on Your own behalf and on Your sole responsibility, not on behalf\n\
+      of any other Contributor, and only if You agree to indemnify,\n\
+      defend, and hold each Contributor harmless for any liability\n\
+      incurred by, or claims asserted against, such Contributor by reason\n\
+      of your accepting any such warranty or additional liability.\n\
+\n\
+   END OF TERMS AND CONDITIONS\n\

--- a/modules/solutions/http-analytics/features/org.wso2.sp.solutions.http.analytics.feature/pom.xml
+++ b/modules/solutions/http-analytics/features/org.wso2.sp.solutions.http.analytics.feature/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.wso2.sp.solutions.http.analytics.feature</artifactId>
+    <packaging>carbon-feature</packaging>
+    <name>WSO2 Stream Processor - Solutions - HTTP Analytics - Feature</name>
+    <url>http://wso2.org</url>
+
+    <parent>
+        <groupId>org.wso2.sp</groupId>
+        <artifactId>http-analytics</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+
+    <dependencies>
+        <!-- Widgets-->
+        <dependency>
+            <groupId>org.wso2.sp</groupId>
+            <artifactId>org.wso2.sp.solutions.widgets.http.analytics.latency.comparison</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.sp</groupId>
+            <artifactId>org.wso2.sp.solutions.widgets.http.analytics.latency</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.sp</groupId>
+            <artifactId>org.wso2.sp.solutions.widgets.http.server.request.count.comparison</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.sp</groupId>
+            <artifactId>org.wso2.sp.solutions.widgets.http.server.request.count</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.sp</groupId>
+            <artifactId>org.wso2.sp.solutions.widgets.http.analytics.request.statistics</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.sp</groupId>
+            <artifactId>org.wso2.sp.solutions.widgets.http.analytics.request.count.filter</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.sp</groupId>
+            <artifactId>org.wso2.sp.solutions.widgets.http.analytics.response.code.filter</artifactId>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>unpack-sample-widgets</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeArtifactIds>
+                                org.wso2.sp.solutions.widgets.http.analytics.latency.comparison,
+                                org.wso2.sp.solutions.widgets.http.analytics.latency,
+                                org.wso2.sp.solutions.widgets.http.server.request.count.comparison,
+                                org.wso2.sp.solutions.widgets.http.server.request.count,
+                                org.wso2.sp.solutions.widgets.http.analytics.request.statistics,
+                                org.wso2.sp.solutions.widgets.http.analytics.request.count.filter,
+                                org.wso2.sp.solutions.widgets.http.analytics.response.code.filter
+                            </includeArtifactIds>
+                            <outputDirectory>${project.build.directory}/widgets/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.wso2.carbon.maven</groupId>
+                <artifactId>carbon-feature-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>1-p2-feature-generation</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <propertyFile>../etc/feature.properties</propertyFile>
+                            <adviceFileContents>
+                                <advice>
+                                    <name>org.wso2.carbon.p2.category.type</name>
+                                    <value>server</value>
+                                </advice>
+                                <advice>
+                                    <name>org.eclipse.equinox.p2.type.group</name>
+                                    <value>false</value>
+                                </advice>
+                            </adviceFileContents>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${project.build.directory}</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+    </build>
+
+</project>

--- a/modules/solutions/http-analytics/features/org.wso2.sp.solutions.http.analytics.feature/src/main/resources/p2.inf
+++ b/modules/solutions/http-analytics/features/org.wso2.sp.solutions.http.analytics.feature/src/main/resources/p2.inf
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+metaRequirements.0.namespace = org.eclipse.equinox.p2.iu
+metaRequirements.0.name = org.wso2.carbon.extensions.touchpoint
+metaRequirements.0.optional = true
+
+instructions.configure = \
+org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../{runtime}/deployment/);\
+org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../{runtime}/deployment/web-ui-apps/);\
+org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../{runtime}/deployment/web-ui-apps/portal/);\
+org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../{runtime}/deployment/web-ui-apps/portal/extensions/);\
+org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../{runtime}/deployment/web-ui-apps/portal/extensions/widgets/);\
+org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.sp.solutions.http.analytics_${feature.version}/widgets/,target:${installFolder}/../{runtime}/deployment/web-ui-apps/portal/extensions/widgets/,overwrite:true);\
+org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/../lib/features/org.wso2.sp.solutions.http.analytics_${feature.version}/widgets/);

--- a/modules/solutions/http-analytics/pom.xml
+++ b/modules/solutions/http-analytics/pom.xml
@@ -31,6 +31,7 @@
 
     <modules>
         <module>widgets</module>
+        <module>features/org.wso2.sp.solutions.http.analytics.feature</module>
     </modules>
 
 </project>

--- a/modules/solutions/http-analytics/widgets/pom.xml
+++ b/modules/solutions/http-analytics/widgets/pom.xml
@@ -33,6 +33,13 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>HTTPAnalyticsRequestCountFilter</module>
+        <module>HTTPAnalyticsResponseCodeFilter</module>
+        <module>HTTPAnalyticsRequestCountOverTime</module>
+        <module>HTTPAnalyticsRequestCountComparison</module>
+        <module>HTTPAnalyticsRequestStatistics</module>
         <module>HTTPAnalyticsLatencyOverTime</module>
+        <module>HTTPAnalyticsLatencyComparison</module>
     </modules>
+
 </project>

--- a/modules/solutions/pom.xml
+++ b/modules/solutions/pom.xml
@@ -33,4 +33,5 @@
         <module>twitter-analytics</module>
         <module>http-analytics</module>
     </modules>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -690,9 +690,9 @@
                 <type>zip</type>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.analytics-common</groupId>
+                <groupId>org.wso2.carbon.analytics</groupId>
                 <artifactId>org.wso2.carbon.analytics.auth.rest.api</artifactId>
-                <version>${carbon.analytics-common.version}</version>
+                <version>${carbon.analytics.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.analytics</groupId>
@@ -780,6 +780,60 @@
                 <groupId>org.wso2.carbon.privacy</groupId>
                 <artifactId>org.wso2.carbon.privacy.forgetme.tool</artifactId>
                 <version>${forgetme.tool.version}</version>
+            </dependency>
+
+            <!-- HTTP Analytics Widgets -->
+            <!--Widgets-->
+            <dependency>
+                <groupId>org.wso2.sp</groupId>
+                <artifactId>org.wso2.sp.solutions.widgets.http.analytics.latency.comparison</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.sp</groupId>
+                <artifactId>org.wso2.sp.solutions.widgets.http.analytics.latency</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.sp</groupId>
+                <artifactId>org.wso2.sp.solutions.widgets.http.server.request.count.comparison</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.sp</groupId>
+                <artifactId>org.wso2.sp.solutions.widgets.http.server.request.count</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.sp</groupId>
+                <artifactId>org.wso2.sp.solutions.widgets.http.analytics.request.statistics</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.sp</groupId>
+                <artifactId>org.wso2.sp.solutions.widgets.http.analytics.request.count.filter</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.sp</groupId>
+                <artifactId>org.wso2.sp.solutions.widgets.http.analytics.response.code.filter</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
+
+
+            <!-- Solution Features -->
+            <dependency>
+                <groupId>org.wso2.sp</groupId>
+                <artifactId>org.wso2.sp.solutions.http.analytics.feature</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -942,6 +996,11 @@
                             </configuration>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.wso2.carbon.maven</groupId>
+                    <artifactId>carbon-feature-plugin</artifactId>
+                    <version>${carbon.feature.plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## Purpose
Copy the compiled widgets when the SP pack is build

## Goals
During SP back build, this will copy needed HTTP Analytics widgets to the /portal/extension/widget folder

## Approach
Using feature installation to copy resources

## User stories
As a system,
I want to copy the widget resource at every SP pack build
to have the latest copy of the widget

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8.0_131
 
## Learning
N/A