### PR TITLE
Modify message tracer widget names

### DIFF
--- a/modules/solutions/activity-explorer/widgets/OpenTracingList/src/resources/widgetConf.json
+++ b/modules/solutions/activity-explorer/widgets/OpenTracingList/src/resources/widgetConf.json
@@ -1,5 +1,5 @@
 {
-  "name": "List",
+  "name": "TracingList",
   "id": "OpenTracingList",
   "thumbnailURL": "",
   "configs": {

--- a/modules/solutions/activity-explorer/widgets/OpenTracingSearch/src/resources/widgetConf.json
+++ b/modules/solutions/activity-explorer/widgets/OpenTracingSearch/src/resources/widgetConf.json
@@ -1,5 +1,5 @@
 {
-  "name": "Search",
+  "name": "TracingSearch",
   "id": "OpenTracingSearch",
   "thumbnailURL": "",
   "configs": {

--- a/modules/solutions/activity-explorer/widgets/OpenTracingVisTimeline/src/resources/widgetConf.json
+++ b/modules/solutions/activity-explorer/widgets/OpenTracingVisTimeline/src/resources/widgetConf.json
@@ -1,5 +1,5 @@
 {
-  "name": "Timeline",
+  "name": "TracingTimeline",
   "id": "OpenTracingVisTimeline",
   "thumbnailURL": "",
   "configs": {


### PR DESCRIPTION
## Purpose
This PR modifies names of following Message Tracer (Activity Explorer) dashboard.
- OpenTracingList
- OpenTracingVisTimeline
- OpenTracingSearch