### PR TITLE
Fix dashboard run time URL in twitter README

### DIFF
--- a/modules/solutions/twitter-analytics/README.md
+++ b/modules/solutions/twitter-analytics/README.md
@@ -23,9 +23,8 @@ option.
     - On Windows:  `worker.bat --run`
     - On Linux/Mac OS:  `./worker.sh`
 
-+ Access the Business Rules Manager via one of the following URLs.
-    - `http://<SP_HOST>:<HTTP_PORT>/business-rules` **`(eg: http://0.0.0.0:9090/business-rules)`**
-    - `https://<SP_HOST>:<HTTPS_PORT>/business-rules` **`(eg: https://0.0.0.0:9443/business-rules)`**
++ Access the Business Rules Manager via the following URL.
+    - `https://<SP_HOST>:<HTTPS_PORT>/business-rules` **`(eg: https://0.0.0.0:9643/business-rules)`**
 
 + Click on the **CREATE** button (when there are no business rules yet), or the **+** button (when at least one 
 business 
@@ -44,9 +43,8 @@ rule exists).
 + Click on **SAVE & DEPLOY** button.
 
 ##2. Viewing the Twitter Analytics Dashboard
-+ From the dashboard run time, access the Dashboard Portal via one of the following URLs:
-    - `http://<SP_HOST>:<HTTP_PORT>/portal` **`(eg: http://localhost:9290/portal)`**
-    - `https://<SP_HOST>:<HTTPS_PORT>/portal` **`(eg: http://localhost:9643/portal)`**
++ From the dashboard run time, access the Dashboard Portal via the following URLs:
+    - `https://<SP_HOST>:<HTTPS_PORT>/portal` **`(eg: http://0.0.0.0:9643/portal)`**
 
 + Click the **View** button, on the **Twitter Analytics** dashboard.
 


### PR DESCRIPTION
## Purpose
$subject

## Documentation
WSO2 SP solution documentation has the correct URL. (https://docs.wso2.com/display/SP420/Twitter+Analytics)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes