### PR TITLE
Updating to the correct version number

### DIFF
--- a/modules/performance/extension/siddhi-execution-performance/component/pom.xml
+++ b/modules/performance/extension/siddhi-execution-performance/component/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.extension.siddhi.execution.performance</groupId>
         <artifactId>siddhi-execution-performance-parent</artifactId>
-        <version>4.0.0-update2-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/modules/performance/extension/siddhi-execution-performance/pom.xml
+++ b/modules/performance/extension/siddhi-execution-performance/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.wso2.sp</groupId>
         <artifactId>wso2sp-performance</artifactId>
-        <version>4.0.0-update2-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>org.wso2.extension.siddhi.execution.performance</groupId>
     <artifactId>siddhi-execution-performance-parent</artifactId>
-    <version>4.0.0-update2-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Siddhi Execution Performance Extension Parent</name>
     <url>http://wso2.org</url>

--- a/modules/performance/extension/siddhi-execution-performance/pom.xml
+++ b/modules/performance/extension/siddhi-execution-performance/pom.xml
@@ -29,7 +29,6 @@
 
     <groupId>org.wso2.extension.siddhi.execution.performance</groupId>
     <artifactId>siddhi-execution-performance-parent</artifactId>
-    <version>4.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Siddhi Execution Performance Extension Parent</name>
     <url>http://wso2.org</url>


### PR DESCRIPTION
## Purpose
Without the correct version number it is not possible for the throughput extension to be built properly.

## Goals
Fix the issue of throughput extension not getting built properly.

## Test environment
JDK 1.8