### PR TITLE
Removing duplicate dependency entry from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1052,12 +1052,6 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.analytics.solutions</groupId>
-                <artifactId>org.wso2.analytics.solutions.is.analytics.widgets.attempts.over.time</artifactId>
-                <type>zip</type>
-                <version>${analytics.solutions.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.analytics.solutions</groupId>
                 <artifactId>org.wso2.analytics.solutions.is.analytics.widgets.session.count</artifactId>
                 <type>zip</type>
                 <version>${analytics.solutions.version}</version>


### PR DESCRIPTION
## Purpose
> is.analytics.attempts.over.time widget is added twice, and hence there were duplicate entry in the pom file. This is to remove it.