### PR TITLE
Sample(PublishEmailInXmlFormat) instruction correction

### DIFF
--- a/modules/samples/artifacts/PublishEmailInXmlFormat/PublishEmailInXmlFormat.siddhi
+++ b/modules/samples/artifacts/PublishEmailInXmlFormat/PublishEmailInXmlFormat.siddhi
@@ -31,8 +31,9 @@ Testing the Sample:
 
 Viewing the Results:
     Check the receiver gmail inbox (The gmail referred to in 'to' Sink configuration) to see the alert as follows.
-        Subject: Alert
-        Content: <events><event><name>chocolate cake</name><hourlyTotal>12.12</hourlyTotal><currentHour>0.0</currentHour></event></events>
+    Note: current hour depends on the system's timestamp
+        Subject: <subject of the email>
+        Content: <events><event><name>chocolate cake</name><hourlyTotal>10.1</hourlyTotal><currentHour>0.0</currentHour></event></events>
 
 */
 


### PR DESCRIPTION
## Purpose
>The instruction in the sample "PublishEmailInXmlFormat" needs to be edited
## Goals
> In the instruction as it is stated under viewing the result is different from the actual email(output) received.

## Approach
> Existing Instruction 
![screenshot from 2018-09-11 14-33-58](https://user-images.githubusercontent.com/32606884/45349996-6eb54a80-b5d0-11e8-895e-de36c3883b96.png)

>Updated Instruction
![screenshot from 2018-09-11 14-38-30](https://user-images.githubusercontent.com/32606884/45350024-7b39a300-b5d0-11e8-908e-8031321edc6d.png)

