### PR TITLE
Fixes quote escaping issues in the sample siddhi app's curl test.

### DIFF
--- a/modules/samples/artifacts/PublishJmsInKeyvalueFormat/PublishJmsInKeyvalueFormat.siddhi
+++ b/modules/samples/artifacts/PublishJmsInKeyvalueFormat/PublishJmsInKeyvalueFormat.siddhi
@@ -65,7 +65,7 @@ Testing the Sample:
         Option 2:
          Publish events with Curl command to the simulator http endpoint:
             a) Open a new terminal and issue the following command:
-                * curl -X POST -d '{"streamName": "SweetProductionStream", "siddhiAppName": "PublishJmsInKeyvalueFormat","data": ['chocolate cake', 50.50]}' http://localhost:9390/simulation/single -H 'content-type: text/plain'
+                * curl -X POST -d '{"streamName": "SweetProductionStream", "siddhiAppName": "PublishJmsInKeyvalueFormat","data": ["chocolate cake", 50.50]}' http://localhost:9390/simulation/single -H 'content-type: text/plain'
             b) If there is no error, the following messages are shown on the terminal:
                 *  {"status":"OK","message":"Single Event simulation started successfully"}
 

--- a/modules/samples/artifacts/PublishJmsInXmlFormat/PublishJmsInXmlFormat.siddhi
+++ b/modules/samples/artifacts/PublishJmsInXmlFormat/PublishJmsInXmlFormat.siddhi
@@ -65,7 +65,7 @@ Testing the Sample:
         Option 2:
          Publish events with Curl command to the simulator http endpoint:
             a) Open a new terminal and issue the following command:
-                * curl -X POST -d '{"streamName": "SweetProductionStream", "siddhiAppName": "PublishJmsInXmlFormat","data": ['chocolate cake', 50.50]}' http://localhost:9390/simulation/single -H 'content-type: text/plain'
+                * curl -X POST -d '{"streamName": "SweetProductionStream", "siddhiAppName": "PublishJmsInXmlFormat","data": ["chocolate cake", 50.50]}' http://localhost:9390/simulation/single -H 'content-type: text/plain'
             b) If there is no error, the following messages are shown on the terminal:
                 *  {"status":"OK","message":"Single Event simulation started successfully"}
 


### PR DESCRIPTION

## Purpose
>Removing the quote escaping issues in the curl test commands provided for sample Siddhi applications.

## Approach
>Using same type of quotes inside the curl's data field.
