### PR TITLE
Rename WSO2_CARBON_DB to WSO2_CLUSTER_DB by default in Worker profile

### DIFF
--- a/modules/distribution/carbon-home/conf/worker/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/worker/deployment.yaml
@@ -324,7 +324,10 @@ wso2.securevault:
 wso2.datasources:
   dataSources:
     -
+      name: WSO2_CLUSTER_DB
+      description: "The datasource used by cluster coordinators in HA deployment"
       definition:
+        type: RDBMS
         configuration:
           connectionTestQuery: "SELECT 1"
           driverClassName: org.h2.Driver
@@ -335,9 +338,6 @@ wso2.datasources:
           password: wso2carbon
           username: wso2carbon
           validationTimeout: 30000
-        type: RDBMS
-      description: "The datasource used for registry and user manager"
-      name: WSO2_CARBON_DB
 
     # carbon metrics data source
     - name: WSO2_METRICS_DB
@@ -539,7 +539,7 @@ cluster.config:
   groupId:  sp
   coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
   strategyConfig:
-    datasource: WSO2_CARBON_DB
+    datasource: WSO2_CLUSTER_DB
     heartbeatInterval: 1000
     heartbeatMaxRetry: 2
     eventPollingInterval: 1000

--- a/modules/distribution/carbon-home/conf/worker/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/worker/deployment.yaml
@@ -333,7 +333,7 @@ wso2.datasources:
           driverClassName: org.h2.Driver
           idleTimeout: 60000
           isAutoCommit: false
-          jdbcUrl: "jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CLUSTER_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
+          jdbcUrl: "jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CLUSTER_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE"
           maxPoolSize: 10
           password: wso2carbon
           username: wso2carbon

--- a/modules/distribution/carbon-home/conf/worker/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/worker/deployment.yaml
@@ -333,7 +333,7 @@ wso2.datasources:
           driverClassName: org.h2.Driver
           idleTimeout: 60000
           isAutoCommit: false
-          jdbcUrl: "jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
+          jdbcUrl: "jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CLUSTER_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
           maxPoolSize: 10
           password: wso2carbon
           username: wso2carbon


### PR DESCRIPTION
## Purpose
WSO2_CARBON_DB datasource in the configs was only used for carbon coordination in configs in HA mode by default. This can be renamed to above for higher maintainability.

## Documentation (SP4xx space)
1. Following to be updated that WSO2_CLUSTER_DB already defined, however, to ensure it points to only one DB in both nodes, if the nodes are in 2 different hosts. (Step 2 d)
https://docs.wso2.com/display/SP400/Minimum+High+Availability+%28HA%29+Deployment
2. Sample value to be updated 
https://docs.wso2.com/display/SP430/Configuring+Cluster+Coordination
3. The default value to be updated in HA mode
https://docs.wso2.com/display/SP430/Configuring+Datasources

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes