### PR TITLE
Add documentation for HTTP transport with expired access token

### DIFF
--- a/modules/samples/artifacts/PublishHttpWithExpiredToken/PublishHttpWithExpiredToken.siddhi
+++ b/modules/samples/artifacts/PublishHttpWithExpiredToken/PublishHttpWithExpiredToken.siddhi
@@ -1,0 +1,83 @@
+@App:name("PublishHttpWithExpiredToken")
+
+@App:description("Send events via HTTP transport with expired token")
+/*
+Purpose:
+	This application demonstrates how to configure WSO2 Stream Processor to send an events via HTTP transport with expired access token.
+Prerequisites:
+     1) Replace the Sink configuration values for following options.
+            - oauth.username: senders oauth username (Ex:- 'username123')
+            - oauth.password : senders oauth password (Ex:- 'password123')
+            - publisher.url : publisher URL (Ex:- 'https://xxx.xxx.xxx.xxx:xxxx/abc/abc')
+            - consumer.key  : consumer key for the http request (Ex:- 'abcdef')
+            - consumer.secret: consumer secret for the http request (Ex:- 'abcdef')
+
+            optional (You can fill this if it is different from default values )
+            - header (Authorization header)  : access token for the http request (Ex:- 'abcdef') <= by default it automatically get the access token using consumer.key, consumer.secret
+            - https.truststore.file : API trust store path (Ex:- '/user/../../../client-truststore.jks') <= by default it get from product pack (Ex:- ${carbon.home}/resources/security/client-truststore.jks)
+            - https.truststore.password :  API trust store password (wso2carbon) <= by default it set as wso2carbon
+            - refresh.token : Refresh token for the http request
+     2) Save one of the convenient sample mention below and configure the values. If there is no syntax error, the following message is shown on the console:
+                 * Siddhi App PublishHttpInJsonFormat successfully deployed.
+
+Executing the Sample:
+	1) Start the Siddhi application by clicking on 'Run'.
+
+	2) If the Siddhi application starts successfully, the following messages are shown on the console:
+            * PublishHttpWithExpiredToken.siddhi - Started Successfully!
+            * 'Http' sink at 'xxxxxxxxxx' stream successfully connected to 'https://xxx.xxx.xxx.xxx:xxxx/abc/abc'.
+
+Testing the Sample:
+    1) Click on 'Event Simulator' (double arrows on left tab)
+
+    2) Click 'Single Simulation' (this will be already selected)
+
+    3) Select PublishHttpWithInvalidToken as 'Siddhi App Name'
+
+    4) Select FooStream as 'StreamName'
+
+    5) Provide attribute values
+
+    6) Click on the start button (Arrow symbol) next to the newly created simulator
+
+
+Viewing the Results:
+    See the output on the terminal:
+	 INFO {org.wso2.extension.siddhi.io.http.sink.HttpSink} - Request send successfully.
+
+
+ Notes:
+  If you get the message "Error when pushing events to Siddhi debugger engine', it could be due to time out problem, do the following:
+        1) Stop this Siddhi application (Click 'Run' on menu bar -> 'Stop').
+        2) Start the application and check whether the expected output appears on the console.
+
+  If you get the message "401", it could be due to passing invalid parameter problem, do the following:
+        1) Stop this Siddhi application (Click 'Run' on menu bar -> 'Stop').
+        2) Recheck the all parameter you are passing and change the correct parameter
+        3) Start the application and check whether the expected output appears on the console.
+
+ If you get the message "500", it could be due to Internal server error problem, do the following:
+        1) Stop this Siddhi application (Click 'Run' on menu bar -> 'Stop').
+        2) Start the application again and check whether the expected output appears on the console.
+
+*/
+
+-- this example contain without access token
+ @sink(type='http', oauth.username="xxxx", method="{{method}}", oauth.password="xxxx",
+ publisher.url='https://xxx.xxx.xxx.xxx:xxxx/abc/abc', headers="'Content-Type: xxxxx'",
+ consumer.key="xxxxxxxxxx", consumer.secret="xxxxxxxxxxx",
+ @map(type='json'))
+ define stream FooStream ( method string);
+
+-- this example contain Auth header, trust file username and password
+--  @sink(type='http', method="xxxx", oauth.username="xxxx", oauth.password="xxxx",
+--  publisher.url='https://xxx.xxx.xxx.xxx:xxxx/abc/abc', headers="'Authorization:  Bearer xxxxxxxxx'",
+--  https.truststore.file="/Users/xxxx/xxxx..../client-truststore.jks", https.truststore.password="xxxxxx", method="{{method}}",
+--  @map(type='json'))
+--  define stream FooStream ( method string);
+
+-- this example contain with refresh token
+-- @sink(type='http', refresh.token="{{refresh.token}}", publisher.url='https://xxx.xxx.xxx.xxx:xxxx/abc/abc',
+-- headers="'Content-Type: xxxxx'", consumer.key="xxxxxxxxxx", consumer.secret="xxxxxxxxxxx",
+-- @map(type='json'))
+-- define stream FooStream ( refresh.token string);

--- a/modules/samples/artifacts/PublishHttpWithExpiredToken/PublishReciveHttpWithExpiredToken.siddhi
+++ b/modules/samples/artifacts/PublishHttpWithExpiredToken/PublishReciveHttpWithExpiredToken.siddhi
@@ -1,0 +1,99 @@
+@App:name("PublishReciveHttpWithExpiredToken")
+
+@App:description("Send and get response events via HTTP transport with expired token ")
+/*
+Purpose:
+	This application demonstrates how to configure WSO2 Stream Processor to send and receive an events via HTTP transport with expired access token.
+Prerequisites:
+
+     1) Replace the Sink configuration values for following options.
+            - oauth.username: senders oauth username (Ex:- 'username123')
+            - oauth.password : senders oauth password (Ex:- 'password123')
+            - publisher.url : publisher URL (Ex:- 'https://xxx.xxx.xxx.xxx:xxxx/abc/abc')
+            - consumer.key  : consumer key for the http request (Ex:- 'abcdef')
+            - consumer.secret: consumer secret for the http request (Ex:- 'abcdef')
+
+            optional (You can fill this if it is different from default values )
+             - header (Authorization header)  : access token for the http request (Ex:- 'abcdef') <= by default it automatically get the access token using consumer.key, consumer.secret
+             - https.truststore.file : API trust store path (Ex:- '/user/../../../client-truststore.jks') <= by default it get from product pack (Ex:- ${carbon.home}/resources/security/client-truststore.jks)
+             - https.truststore.password :  API trust store password (wso2carbon) <= by default it set as wso2carbon
+             - refresh.token : Refresh token for the http request
+
+     2) Save one of the convenient sample mention below and configure the values. If there is no syntax error, the following message is shown on the console:
+             * Siddhi App PublishHttpInJsonFormat successfully deployed.
+
+Executing the Sample:
+	1) Start the Siddhi application by clicking on 'Run'.
+
+	2) If the Siddhi application starts successfully, the following messages are shown on the console:
+            * PublishHttpWithExpiredToken.siddhi - Started Successfully!
+            * 'Http' sink at 'xxxxxxxxxx' stream successfully connected to 'https://xxx.xxx.xxx.xxx:xxxx/abc/abc'.
+
+Testing the Sample:
+    1) Click on 'Event Simulator' (double arrows on left tab)
+
+    2) Click 'Single Simulation' (this will be already selected)
+
+    3) Select PublishHttpWithInvalidToken as 'Siddhi App Name'
+
+    4) Select FooStream as 'StreamName'
+
+    5) Provide attribute values
+
+    6) Click on the start button (Arrow symbol) next to the newly created simulator
+
+
+Viewing the Results:
+    See the output on the terminal:
+	 INFO {org.wso2.extension.siddhi.io.http.sink.HttpSink} - Request send successfully.
+
+
+ Notes:
+  If you get the message "Error when pushing events to Siddhi debugger engine', it could be due to time out problem, do the following:
+        1) Stop this Siddhi application (Click 'Run' on menu bar -> 'Stop').
+        2) Start the application and check whether the expected output appears on the console.
+
+  If you get the message "401", it could be due to passing parameter problem, do the following:
+        1) Stop this Siddhi application (Click 'Run' on menu bar -> 'Stop').
+        2) Recheck the all parameter you are passing and change the correct parameter
+        3) Start the application and check whether the expected output appears on the console.
+
+  If you get the message "500", it could be due to Internal server error problem, do the following:
+        1) Stop this Siddhi application (Click 'Run' on menu bar -> 'Stop').
+        2) Start the application again and check whether the expected output appears on the console.
+
+*/
+
+-- this example contain without access token
+ @sink(type='http-request', sink.id='abcd', oauth.username="xxxx", oauth.password="xxxx",  method="{{method}}",
+  publisher.url='https://xxx.xxx.xxx.xxx:xxxx/abc/abc', headers="'Content-Type: xxxxx'",
+  consumer.key="xxxxxxxxxxx", consumer.secret="xxxxxxxxxxxxxxxx",  @map(type='json'))
+ define stream FooStream ( method string );
+
+  @source(type='http-response' , sink.id='abcd', http.status.code='200',
+  @map(type='text', regex.A='((.|\n)*)', @attributes(message='A[1]')))
+  define stream responseStream2xx(message string);
+
+-- this example contain Auth header, trust file username and password
+-- @sink(type='http-request', sink.id='abcd', method="xxx", oauth.username="xxxx", oauth.password="xxxxx",
+-- publisher.url='https://xxx.xxx.xxx.xxx:xxxx/abc/abc', headers="'Authorization:  Bearer xxxxxxxxxxxxx',
+-- 'Content-Type: xxxx'", https.truststore.file="/Users/xxxxx/xxxxx/xxxx...../client-truststore.jks", method="{{method}}",
+-- https.truststore.password="xxxx", consumer.key="xxxxxx", consumer.secret="xxxxxxx",
+-- @map(type='json'))
+-- define stream FooStream ( method string );
+
+-- @source(type='http-response' , sink.id='abcd', http.status.code='200',
+-- @map(type='text', regex.A='((.|\n)*)', @attributes(message='A[1]')))
+-- define stream responseStream2xx(message string);
+
+
+-- this example contain refresh token
+-- @sink(type='http-request', sink.id='abcd', method="xxx", refresh.token={{refresh.token}},
+-- publisher.url='https://xxx.xxx.xxx.xxx:xxxx/abc/abc', headers="'Authorization:  Bearer xxxxxxxxxxxxx',
+-- 'Content-Type: xxxx'", consumer.key="xxxxxxx", consumer.secret="xxxxxxxx",
+-- @map(type='json'))
+-- define stream FooStream ( consumer_key string, consumer_secret string );
+
+-- @source(type='http-response' , sink.id='abcd', http.status.code='200',
+-- @map(type='text', regex.A='((.|\n)*)', @attributes(message='A[1]')))
+-- define stream responseStream2xx(message string);


### PR DESCRIPTION
## Purpose
> Using Siddhi-IO-HTTP, we can make a connection with the API Manager. Sometimes when we connect with APIM we get "Authentication failure" as a response because of the access token expired. This is the proper explanation about how to write a siddhi application to solve this issue. It includes examples and documentation.
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no