### PR TITLE
Add samples for Google Pub/Sub

### DIFF
--- a/modules/samples/artifacts/PublishEventsToPubSub/PublishGooglePubSubMessagesInTextFormat.siddhi
+++ b/modules/samples/artifacts/PublishEventsToPubSub/PublishGooglePubSubMessagesInTextFormat.siddhi
@@ -59,5 +59,3 @@ define stream BarStream(message string);
 from FooStream
 select message 
 insert into BarStream;
-
-

--- a/modules/samples/artifacts/PublishEventsToPubSub/PublishGooglePubSubMessagesInTextFormat.siddhi
+++ b/modules/samples/artifacts/PublishEventsToPubSub/PublishGooglePubSubMessagesInTextFormat.siddhi
@@ -1,0 +1,63 @@
+@App:name("SendGooglePubSubMessage")
+
+@App:description('Send events to a Google Pub/Sub Topic')
+
+/*
+
+Purpose:
+    This application demonstrates how to configure WSO2 Stream Processor using googlepubsub sink in Siddhi to publish events. Events which are in TEXT format are published to a googlepubsub topic.
+
+Prerequisites:
+   1.Create a Google Cloud Platform account.
+   2.Sign in to Google Account and set up a GCP Console project and enable the API.
+   3.Create a service account and download a private key as JSON.
+   4.Place your json file in any system property.
+   5.Save the sample.
+   6.If there is no syntax error, the following message is shown on the console:
+	        * -Siddhi App SendGooglePubSubMessage successfully deployed.
+
+
+Executing the Sample:
+	1) Start the Siddhi application by clicking on 'Run'.
+
+	* If the Siddhi application starts successfully, the following messages are shown on the console:
+    	- SendGooglePubSubMessage.siddhi - Started Successfully!
+
+Testing the Sample:
+    1) Send events through one or more of the following methods.
+
+         You may send events to googlepubsub sink, via event simulator
+            a) Open the event simulator by clicking on the second icon or pressing Ctrl+Shift+I.
+            b) In the Single Simulation tab of the panel, specify the values as follows:
+                    * Siddhi App Name  : SendGooglePubSubMessage
+                    * Stream Name      : FooStream
+            c) In the message field, enter the following and then click Send to send the event.
+                    message: Hello
+            d) Send some more events.
+
+Viewing the Results:
+    See the output on the terminal:
+2019-03-14_12-50-21_966] INFO {org.wso2.siddhi.core.stream.output.sink.LogSink} - SendEvent : BarStream : Event{timestamp=1552548021825, data=[Hello], isExpired=false} 
+
+Notes:
+	Make sure the the credential file is correct and user have write access to make api calls.
+        Stop this Siddhi application.
+*/
+
+
+@sink(type='googlepubsub', 
+      topic.id = 'topic75',
+      credential.path = '/../sp.json',
+      project.id = 'sp-path-1547649404768',
+      @map(type='text'))
+define stream FooStream (message string);
+
+@sink(type = 'log')
+define stream BarStream(message string);
+
+@info(name = 'query1')
+from FooStream
+select message 
+insert into BarStream;
+
+

--- a/modules/samples/artifacts/ReceivePubSubEvents/ReceiveGooglePubSubMessagesInTextFormat.siddhi
+++ b/modules/samples/artifacts/ReceivePubSubEvents/ReceiveGooglePubSubMessagesInTextFormat.siddhi
@@ -55,6 +55,3 @@ define stream BarStream(message string);
     from FooStream 
     select message 
     insert into BarStream;
-
-
-

--- a/modules/samples/artifacts/ReceivePubSubEvents/ReceiveGooglePubSubMessagesInTextFormat.siddhi
+++ b/modules/samples/artifacts/ReceivePubSubEvents/ReceiveGooglePubSubMessagesInTextFormat.siddhi
@@ -1,0 +1,60 @@
+@App:name("ReceiveGooglePubSubMesssage")
+
+@App:description('Consume messages from a googlepubsub Topic.')
+
+/*
+Purpose:
+    This application demonstrates how to configure WSO2 Stream Processor using googlepubsub source in Siddhi to consume events. Events which are in TEXT format are consumed from a googlepubsub topic.
+
+Prerequisites:
+   1.Create a Google Cloud Platform account.
+   2.Sign in to Google Account and set up a GCP Console project and enable the API.
+   3.Create a service account and download a private key as JSON.
+   4.Place your json file in any system folder and provide the path for the credential.path.
+   5.Save the sample.
+   6.If there is no syntax error, the following message is shown on the console:
+	        * -Siddhi App ReceiveGooglePubSubMesssage successfully deployed.
+ 
+
+Executing the Sample:
+    1) Start the Siddhi application by clicking on 'Run'
+    2) If the Siddhi application starts successfully, the following messages would be shown on the console,
+        * ReceiveGooglePubSubMesssage.siddhi - Started Successfully!
+
+Testing the Sample:
+  1) Receive events through the following,
+         You may listen to the events coming to a topic after the subscription is made.
+           
+
+Viewing the Results:
+    See the output on the terminal:
+ INFO {org.wso2.siddhi.core.stream.output.sink.LogSink} - ReceiveEvent : BarStream : Event{timestamp=1552548124599, data=[message:"Hello"], isExpired=false} (Encoded)
+
+Notes:
+	Make sure the the credential file is correct and user have write access to make api calls.
+        Stop this Siddhi application
+*/
+
+@App:name("ReceiveEvent")
+@App:description("Listen for messages received for a topic in Google Pub Sub Server.")
+
+
+@source(type ='googlepubsub', 
+                project.id = 'sp-path-1547649404768', 
+                topic.id = 'topic75',
+                credential.path = '/../sp.json',
+                subscription.id = 'sub75', 
+                @map(type = 'text'))
+
+define stream FooStream (message string); 
+                
+@sink(type='log')
+define stream BarStream(message string);
+
+@info(name='EventsPassthroughQuery')
+    from FooStream 
+    select message 
+    insert into BarStream;
+
+
+


### PR DESCRIPTION
## Purpose
> The samples with instructions of how to publish a message to a googlepubsub topic and how to consume a message from a googlepubsub topic that is published to the particular topic.

## Goals
> To easify the task of using the connector to exchange messages reliably, quickly and asynchonously using this connector.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Samples related to publishing a message to the googlepubsub server and receive messages from googlepubsub server.
