### PR TITLE
added samples for siddhi-io-hl7

### DIFF
--- a/modules/samples/artifacts/PublishHl7InEr7Format/PublishHl7InER7Format.siddhi
+++ b/modules/samples/artifacts/PublishHl7InEr7Format/PublishHl7InER7Format.siddhi
@@ -1,0 +1,41 @@
+@App:name('PublishHl7InER7Format')
+@App:description('This publishes the HL7 messages in ER7 format, receives and logs the acknowledgement message in the console using MLLP protocol and custom text mapping.')
+
+/*
+
+Purpose:
+    This application demonstrates how to configure WSO2 Stream Processor to send Hl7 events in ER7 format via MLLP protocol and log the events in hl7Stream and the acknowledgement message to the output console.
+
+Prerequisites:
+    * Install the HAPI testpanel. (Reference: https://hapifhir.github.io/hapi-hl7v2/hapi-testpanel/install.html)
+	* Save this sample. If there is no syntax error, the following message is shown on the console:
+	     * - Siddhi App PublishHl7InER7Format successfully deployed.
+
+Executing the Sample:
+    1) In the HAPI testpanel create a receiving connection with port that provided in the siddhi app.
+    2) Start the listener.
+	3) Start the Siddhi application by clicking on 'Run'.
+	4) If the Siddhi application starts successfully, the following messages are shown on the console:
+            * PublishHl7InER7Format.siddhi - Started Successfully!
+            * 'Hl7' sink at 'hl7Stream' stream successfully connected to 'localhost:4000'.
+            * Executing HL7Sender: HOST: localhost, PORT: 4000 for stream PublishHl7InER7Format:hl7Stream.
+
+Testing the Sample:
+    1) Open the event simulator by clicking on the second icon or pressing Ctrl+Shift+I.
+    2) In the Single Simulation tab of the panel, specifiy the values as follows:
+            * Siddhi App Name  : PublishHl7InER7Format
+            * Stream Name      : er7Stream
+    3) In the payload, enter 'MSH|^~\&|||||20190211145413.131+0530||ADT^A01|10601|T|2.3' and then click Send to send the event.
+    4) Send more events as desired.
+
+*/
+
+define stream er7Stream (payload string);
+
+@sink(type = 'hl7', uri='localhost:4000', tls.enabled='false', hl7.encoding='er7', @map(type='text', @payload('{{payload}}')))
+define stream hl7Stream (payload String);
+
+@info(name='query1')
+from er7Stream
+select payload
+insert into hl7Stream;

--- a/modules/samples/artifacts/PublishHl7InEr7Format/PublishHl7InER7Format.siddhi
+++ b/modules/samples/artifacts/PublishHl7InEr7Format/PublishHl7InER7Format.siddhi
@@ -6,9 +6,9 @@ Purpose:
     This application demonstrates how to configure WSO2 Stream Processor to send Hl7 events in ER7 format via MLLP protocol and log the events in hl7Stream and the acknowledgement message to the output console.
 
 Prerequisites:
-    * Install the HAPI testpanel. (Reference: https://hapifhir.github.io/hapi-hl7v2/hapi-testpanel/install.html)
-	* Save this sample. If there is no syntax error, the following message is shown on the console:
-	    * - Siddhi App PublishHl7InER7Format successfully deployed.
+    1) Install the HAPI testpanel. (Reference: https://hapifhir.github.io/hapi-hl7v2/hapi-testpanel/install.html)
+    2) Save this sample. If there is no syntax error, the following message is shown on the console:
+        * - Siddhi App PublishHl7InER7Format successfully deployed.
 
 Executing the Sample:
     1) In the HAPI testpanel create a receiving connection with port that provided in the siddhi app.

--- a/modules/samples/artifacts/PublishHl7InEr7Format/PublishHl7InER7Format.siddhi
+++ b/modules/samples/artifacts/PublishHl7InEr7Format/PublishHl7InER7Format.siddhi
@@ -2,32 +2,30 @@
 @App:description('This publishes the HL7 messages in ER7 format, receives and logs the acknowledgement message in the console using MLLP protocol and custom text mapping.')
 
 /*
-
 Purpose:
     This application demonstrates how to configure WSO2 Stream Processor to send Hl7 events in ER7 format via MLLP protocol and log the events in hl7Stream and the acknowledgement message to the output console.
 
 Prerequisites:
     * Install the HAPI testpanel. (Reference: https://hapifhir.github.io/hapi-hl7v2/hapi-testpanel/install.html)
 	* Save this sample. If there is no syntax error, the following message is shown on the console:
-	     * - Siddhi App PublishHl7InER7Format successfully deployed.
+	    * - Siddhi App PublishHl7InER7Format successfully deployed.
 
 Executing the Sample:
     1) In the HAPI testpanel create a receiving connection with port that provided in the siddhi app.
     2) Start the listener.
 	3) Start the Siddhi application by clicking on 'Run'.
 	4) If the Siddhi application starts successfully, the following messages are shown on the console:
-            * PublishHl7InER7Format.siddhi - Started Successfully!
-            * 'Hl7' sink at 'hl7Stream' stream successfully connected to 'localhost:4000'.
-            * Executing HL7Sender: HOST: localhost, PORT: 4000 for stream PublishHl7InER7Format:hl7Stream.
+	    * PublishHl7InER7Format.siddhi - Started Successfully!
+	    * 'Hl7' sink at 'hl7Stream' stream successfully connected to 'localhost:4000'.
+	    * Executing HL7Sender: HOST: localhost, PORT: 4000 for stream PublishHl7InER7Format:hl7Stream.
 
 Testing the Sample:
     1) Open the event simulator by clicking on the second icon or pressing Ctrl+Shift+I.
     2) In the Single Simulation tab of the panel, specifiy the values as follows:
-            * Siddhi App Name  : PublishHl7InER7Format
-            * Stream Name      : er7Stream
+        * Siddhi App Name  : PublishHl7InER7Format
+        * Stream Name      : er7Stream
     3) In the payload, enter 'MSH|^~\&|||||20190211145413.131+0530||ADT^A01|10601|T|2.3' and then click Send to send the event.
     4) Send more events as desired.
-
 */
 
 define stream er7Stream (payload string);

--- a/modules/samples/artifacts/PublishHl7InXmlFormat/PublishHl7InXmlFormat.siddhi
+++ b/modules/samples/artifacts/PublishHl7InXmlFormat/PublishHl7InXmlFormat.siddhi
@@ -1,0 +1,40 @@
+@App:name('PublishHl7InXmlFormat')
+@App:description('This publishes the HL7 messages in XML format, receives and logs the acknowledgement message in the console using MLLP protocol and custom xml mapping.')
+
+/*
+
+Purpose:
+	This application demonstrates how to configure WSO2 Stream Processor to send Hl7 events in XML format via MLLP protocol and log the events in hl7Stream and the acknowledgment message to the output console.
+
+Prerequisites:
+    * Install the HAPI testpanel. (Reference: https://hapifhir.github.io/hapi-hl7v2/hapi-testpanel/install.html)
+    * Save this sample. If there is no syntax error, the following message is shown on the console:
+	     * - Siddhi App PublishHl7InXmlFormat successfully deployed.
+
+Executing the Sample:
+    1) In the HAPI testpanel create a receiving connection with port that provided in the siddhi app.
+    2) Start the listener.
+    3) Start the Siddhi application by clicking on 'Run'.
+	4) If the Siddhi application starts successfully, the following messages are shown on the console:
+            * PublishHl7InXmlFormat.siddhi - Started Successfully!
+            * 'Hl7' sink at 'hl7Stream' stream successfully connected to 'localhost:4000'.
+
+Testing the Sample:
+    1) Open the event simulator by clicking on the second icon or pressing Ctrl+Shift+I.
+    2) In the Single Simulation tab of the panel, specifiy the values as follows:
+           * Siddhi App Name  : PublishHl7InER7Format
+            * Stream Name     : er7Stream
+    3) In the MSH1, MSH2, MSH3HD1,MSH4HD1, MSH5HD1, MSH6HD1, MSH7, MSH8, CM_MSG1, CM_MSG2, MSH10, MSH11, MSH12 fields enter '|', '^~\&amp;', 'sendingSystemA', 'senderFacilityA', 'receivingSystemB' , 'receivingFacilityB', '20080925161613', ' ', 'ADT', 'A01', 'S123456789', 'P', '2.3' respectively and then click Send to send the event.
+    4) Send more events as desired.
+
+*/
+
+define stream xmlStream(MSH1 string, MSH2 string, MSH3HD1 string, MSH4HD1 string, MSH5HD1 string, MSH6HD1 string, MSH7 string, MSH8 string, CM_MSG1 string, CM_MSG2 string,MSH10 string,MSH11 string, MSH12 string);
+
+@sink(type = 'hl7', uri = 'localhost:4000', hl7.encoding = 'xml', @map(type = 'xml', enclosing.element="<ADT_A01  xmlns='urn:hl7-org:v2xml'>", @payload('<MSH><MSH.1>{{MSH1}}</MSH.1><MSH.2>{{MSH2}}</MSH.2><MSH.3><HD.1>{{MSH3HD1}}</HD.1></MSH.3><MSH.4><HD.1>{{MSH4HD1}}</HD.1></MSH.4><MSH.5><HD.1>{{MSH5HD1}}</HD.1></MSH.5><MSH.6><HD.1>{{MSH6HD1}}</HD.1></MSH.6><MSH.7>{{MSH7}}</MSH.7><MSH.8>{{MSH8}}</MSH.8><MSH.9><CM_MSG.1>{{CM_MSG1}}</CM_MSG.1><CM_MSG.2>{{CM_MSG2}}</CM_MSG.2></MSH.9><MSH.10>{{MSH10}}</MSH.10><MSH.11>{{MSH11}}</MSH.11><MSH.12>{{MSH12}}</MSH.12></MSH>')))
+define stream hl7Stream(MSH1 string, MSH2 string, MSH3HD1 string, MSH4HD1 string, MSH5HD1 string, MSH6HD1 string, MSH7 string, MSH8 string, CM_MSG1 string, CM_MSG2 string,MSH10 string,MSH11 string, MSH12 string);
+
+@info(name='query1')
+from xmlStream
+select *
+insert into hl7Stream;

--- a/modules/samples/artifacts/PublishHl7InXmlFormat/PublishHl7InXmlFormat.siddhi
+++ b/modules/samples/artifacts/PublishHl7InXmlFormat/PublishHl7InXmlFormat.siddhi
@@ -6,8 +6,8 @@ Purpose:
     This application demonstrates how to configure WSO2 Stream Processor to send Hl7 events in XML format via MLLP protocol and log the events in hl7Stream and the acknowledgment message to the output console.
 
 Prerequisites:
-    * Install the HAPI testpanel. (Reference: https://hapifhir.github.io/hapi-hl7v2/hapi-testpanel/install.html)
-    * Save this sample. If there is no syntax error, the following message is shown on the console:
+    1) Install the HAPI testpanel. (Reference: https://hapifhir.github.io/hapi-hl7v2/hapi-testpanel/install.html)
+    2) Save this sample. If there is no syntax error, the following message is shown on the console:
         * - Siddhi App PublishHl7InXmlFormat successfully deployed.
 
 Executing the Sample:

--- a/modules/samples/artifacts/PublishHl7InXmlFormat/PublishHl7InXmlFormat.siddhi
+++ b/modules/samples/artifacts/PublishHl7InXmlFormat/PublishHl7InXmlFormat.siddhi
@@ -2,31 +2,29 @@
 @App:description('This publishes the HL7 messages in XML format, receives and logs the acknowledgement message in the console using MLLP protocol and custom xml mapping.')
 
 /*
-
 Purpose:
-	This application demonstrates how to configure WSO2 Stream Processor to send Hl7 events in XML format via MLLP protocol and log the events in hl7Stream and the acknowledgment message to the output console.
+    This application demonstrates how to configure WSO2 Stream Processor to send Hl7 events in XML format via MLLP protocol and log the events in hl7Stream and the acknowledgment message to the output console.
 
 Prerequisites:
     * Install the HAPI testpanel. (Reference: https://hapifhir.github.io/hapi-hl7v2/hapi-testpanel/install.html)
     * Save this sample. If there is no syntax error, the following message is shown on the console:
-	     * - Siddhi App PublishHl7InXmlFormat successfully deployed.
+        * - Siddhi App PublishHl7InXmlFormat successfully deployed.
 
 Executing the Sample:
     1) In the HAPI testpanel create a receiving connection with port that provided in the siddhi app.
     2) Start the listener.
     3) Start the Siddhi application by clicking on 'Run'.
-	4) If the Siddhi application starts successfully, the following messages are shown on the console:
-            * PublishHl7InXmlFormat.siddhi - Started Successfully!
-            * 'Hl7' sink at 'hl7Stream' stream successfully connected to 'localhost:4000'.
+    4) If the Siddhi application starts successfully, the following messages are shown on the console:
+        * PublishHl7InXmlFormat.siddhi - Started Successfully!
+        * 'Hl7' sink at 'hl7Stream' stream successfully connected to 'localhost:4000'.
 
 Testing the Sample:
     1) Open the event simulator by clicking on the second icon or pressing Ctrl+Shift+I.
     2) In the Single Simulation tab of the panel, specifiy the values as follows:
-           * Siddhi App Name  : PublishHl7InER7Format
-            * Stream Name     : er7Stream
+        * Siddhi App Name   :   PublishHl7InER7Format
+        * Stream Name   :   er7Stream
     3) In the MSH1, MSH2, MSH3HD1,MSH4HD1, MSH5HD1, MSH6HD1, MSH7, MSH8, CM_MSG1, CM_MSG2, MSH10, MSH11, MSH12 fields enter '|', '^~\&amp;', 'sendingSystemA', 'senderFacilityA', 'receivingSystemB' , 'receivingFacilityB', '20080925161613', ' ', 'ADT', 'A01', 'S123456789', 'P', '2.3' respectively and then click Send to send the event.
     4) Send more events as desired.
-
 */
 
 define stream xmlStream(MSH1 string, MSH2 string, MSH3HD1 string, MSH4HD1 string, MSH5HD1 string, MSH6HD1 string, MSH7 string, MSH8 string, CM_MSG1 string, CM_MSG2 string,MSH10 string,MSH11 string, MSH12 string);

--- a/modules/samples/artifacts/ReceiveHl7InEr7Format/ReceiveHl7InER7Format.siddhi
+++ b/modules/samples/artifacts/ReceiveHl7InEr7Format/ReceiveHl7InER7Format.siddhi
@@ -1,0 +1,53 @@
+@App:name('ReceiveHl7InER7Format')
+@App:description('This receives the HL7 messages and sends the acknowledgement message to the client using the MLLP protocol and text mapping.')
+
+/*
+
+Purpose:
+	This application demonstrates how to configure WSO2 Stream Processor to receive Hl7 events in ER7 format to the hl7Stream via MLLP protocol and log the events in er7Stream to the output console.
+
+Prerequisites:
+    * Install the HAPI testpanel. (Reference: https://hapifhir.github.io/hapi-hl7v2/hapi-testpanel/install.html)
+    * Save this sample. If there is no syntax error, the following message is shown on the console:
+	     * - Siddhi App ReceiveHl7InER7Format successfully deployed. 
+    
+Executing the Sample:
+	1) Start the Siddhi application by clicking on 'Run'.
+    2) If the Siddhi application starts successfully, the following messages would be shown on the console.
+        * Starting SimpleServer running on port 5000 
+        * ReceiveHl7InER7Format.siddhi - Started Successfully!
+
+Testing the Sample:
+    1) In the HAPI testpanel create a sending connection with port that provided in the siddhi app.
+    2) Send this message 'MSH|^~\&|sendingSystemA|senderFacilityA|receivingSystemB|receivingFacilityB|20080925161613||ADT^A01|589888ADT30502184808|P|2.3' from the testpanel
+   
+Viewing the Results:
+    See the output. Following message would be shown on the console if you publish events.
+    ReceiveHl7InER7Format : er7Stream : Event{timestamp=1552530948958, data=[MSH|^~\&|||||20190211145413.131+0530||ADT^A01|10601|T|2.3 ], isExpired=false}
+
+
+
+
+Testing the Sample:
+   1) Open a terminal and navigate to {WSO2SPHome}/samples/sample-clients/http-server and run "ant" command without any arguments.
+   2) Send events using the following method.
+    * Send events with hl7 server through the event simulator:
+        a) Open the event simulator by clicking on the second icon or pressing Ctrl+Shift+I.
+    	b) In the Single Simulation tab of the panel, specifiy the values as follows:
+                * Siddhi App Name  : PublishHl7InER7Format
+                * Stream Name     : er7Stream
+        c) In the payload, enter 'MSH|^~\&|||||20190211145413.131+0530||ADT^A01^ADT_A01|10601|T|2.3' and then click Send to send the event. 
+        d) Send more events as desired.
+
+*/
+
+@source(type = 'hl7', port = '4000', hl7.encoding = 'er7', @map(type = 'text'))
+define stream hl7stream(payload string); 
+
+@sink(type='log')
+define stream er7Stream (payload string);
+
+@info(name='query1')
+from hl7stream
+select *
+insert into er7Stream;

--- a/modules/samples/artifacts/ReceiveHl7InEr7Format/ReceiveHl7InER7Format.siddhi
+++ b/modules/samples/artifacts/ReceiveHl7InEr7Format/ReceiveHl7InER7Format.siddhi
@@ -2,31 +2,27 @@
 @App:description('This receives the HL7 messages and sends the acknowledgement message to the client using the MLLP protocol and text mapping.')
 
 /*
-
 Purpose:
 	This application demonstrates how to configure WSO2 Stream Processor to receive Hl7 events in ER7 format to the hl7Stream via MLLP protocol and log the events in er7Stream to the output console.
 
 Prerequisites:
     * Install the HAPI testpanel. (Reference: https://hapifhir.github.io/hapi-hl7v2/hapi-testpanel/install.html)
     * Save this sample. If there is no syntax error, the following message is shown on the console:
-	     * - Siddhi App ReceiveHl7InER7Format successfully deployed. 
-    
+	     * - Siddhi App ReceiveHl7InER7Format successfully deployed.
+
 Executing the Sample:
 	1) Start the Siddhi application by clicking on 'Run'.
     2) If the Siddhi application starts successfully, the following messages would be shown on the console.
-        * Starting SimpleServer running on port 5000 
+        * Starting SimpleServer running on port 5000
         * ReceiveHl7InER7Format.siddhi - Started Successfully!
 
 Testing the Sample:
     1) In the HAPI testpanel create a sending connection with port that provided in the siddhi app.
     2) Send this message 'MSH|^~\&|sendingSystemA|senderFacilityA|receivingSystemB|receivingFacilityB|20080925161613||ADT^A01|589888ADT30502184808|P|2.3' from the testpanel
-   
+
 Viewing the Results:
     See the output. Following message would be shown on the console if you publish events.
     ReceiveHl7InER7Format : er7Stream : Event{timestamp=1552530948958, data=[MSH|^~\&|||||20190211145413.131+0530||ADT^A01|10601|T|2.3 ], isExpired=false}
-
-
-
 
 Testing the Sample:
    1) Open a terminal and navigate to {WSO2SPHome}/samples/sample-clients/http-server and run "ant" command without any arguments.
@@ -34,15 +30,15 @@ Testing the Sample:
     * Send events with hl7 server through the event simulator:
         a) Open the event simulator by clicking on the second icon or pressing Ctrl+Shift+I.
     	b) In the Single Simulation tab of the panel, specifiy the values as follows:
-                * Siddhi App Name  : PublishHl7InER7Format
-                * Stream Name     : er7Stream
-        c) In the payload, enter 'MSH|^~\&|||||20190211145413.131+0530||ADT^A01^ADT_A01|10601|T|2.3' and then click Send to send the event. 
+    	    * Siddhi App Name  : PublishHl7InER7Format
+    	    * Stream Name     : er7Stream
+        c) In the payload, enter 'MSH|^~\&|||||20190211145413.131+0530||ADT^A01^ADT_A01|10601|T|2.3' and then click Send to send the event.
         d) Send more events as desired.
 
 */
 
 @source(type = 'hl7', port = '4000', hl7.encoding = 'er7', @map(type = 'text'))
-define stream hl7stream(payload string); 
+define stream hl7stream(payload string);
 
 @sink(type='log')
 define stream er7Stream (payload string);

--- a/modules/samples/artifacts/ReceiveHl7InEr7Format/ReceiveHl7InER7Format.siddhi
+++ b/modules/samples/artifacts/ReceiveHl7InEr7Format/ReceiveHl7InER7Format.siddhi
@@ -11,9 +11,9 @@ Prerequisites:
         * - Siddhi App ReceiveHl7InER7Format successfully deployed.
 
 Executing the Sample:
-	1) Start the Siddhi application by clicking on 'Run'.
+    1) Start the Siddhi application by clicking on 'Run'.
     2) If the Siddhi application starts successfully, the following messages would be shown on the console.
-        * Starting SimpleServer running on port 5000
+        * Starting SimpleServer running on port 4000
         * ReceiveHl7InER7Format.siddhi - Started Successfully!
 
 Testing the Sample:

--- a/modules/samples/artifacts/ReceiveHl7InEr7Format/ReceiveHl7InER7Format.siddhi
+++ b/modules/samples/artifacts/ReceiveHl7InEr7Format/ReceiveHl7InER7Format.siddhi
@@ -6,9 +6,9 @@ Purpose:
 	This application demonstrates how to configure WSO2 Stream Processor to receive Hl7 events in ER7 format to the hl7Stream via MLLP protocol and log the events in er7Stream to the output console.
 
 Prerequisites:
-    * Install the HAPI testpanel. (Reference: https://hapifhir.github.io/hapi-hl7v2/hapi-testpanel/install.html)
-    * Save this sample. If there is no syntax error, the following message is shown on the console:
-	     * - Siddhi App ReceiveHl7InER7Format successfully deployed.
+    1) Install the HAPI testpanel. (Reference: https://hapifhir.github.io/hapi-hl7v2/hapi-testpanel/install.html)
+    2) Save this sample. If there is no syntax error, the following message is shown on the console:
+        * - Siddhi App ReceiveHl7InER7Format successfully deployed.
 
 Executing the Sample:
 	1) Start the Siddhi application by clicking on 'Run'.
@@ -23,18 +23,6 @@ Testing the Sample:
 Viewing the Results:
     See the output. Following message would be shown on the console if you publish events.
     ReceiveHl7InER7Format : er7Stream : Event{timestamp=1552530948958, data=[MSH|^~\&|||||20190211145413.131+0530||ADT^A01|10601|T|2.3 ], isExpired=false}
-
-Testing the Sample:
-   1) Open a terminal and navigate to {WSO2SPHome}/samples/sample-clients/http-server and run "ant" command without any arguments.
-   2) Send events using the following method.
-    * Send events with hl7 server through the event simulator:
-        a) Open the event simulator by clicking on the second icon or pressing Ctrl+Shift+I.
-    	b) In the Single Simulation tab of the panel, specifiy the values as follows:
-    	    * Siddhi App Name  : PublishHl7InER7Format
-    	    * Stream Name     : er7Stream
-        c) In the payload, enter 'MSH|^~\&|||||20190211145413.131+0530||ADT^A01^ADT_A01|10601|T|2.3' and then click Send to send the event.
-        d) Send more events as desired.
-
 */
 
 @source(type = 'hl7', port = '4000', hl7.encoding = 'er7', @map(type = 'text'))

--- a/modules/samples/artifacts/ReceiveHl7InXmlFormat/ReceiveHl7InXmlFormat.siddhi
+++ b/modules/samples/artifacts/ReceiveHl7InXmlFormat/ReceiveHl7InXmlFormat.siddhi
@@ -1,0 +1,39 @@
+@App:name('ReceiveHl7InXmlFormat')
+@App:description('This receives the HL7 messages and sends the acknowledgement message to the client using the MLLP protocol and custom xml mapping.')
+
+/*
+
+Purpose:
+	This application demonstrates how to configure WSO2 Stream Processor to receive Hl7 events in XML format to the hl7Stream via MLLP protocol and log the events in xmlStream to the output console.
+
+Prerequisites:
+    * Install the HAPI testpanel. (Reference: https://hapifhir.github.io/hapi-hl7v2/hapi-testpanel/install.html)
+    * Save this sample. If there is no syntax error, the following message is shown on the console:
+	     * - Siddhi App ReceiveHl7InXmlFormat successfully deployed.
+
+Executing the Sample:
+	1) Start the Siddhi application by clicking on 'Run'.
+	2) If the Siddhi application starts successfully, the following messages would be shown on the console.
+        * Starting SimpleServer running on port 5000
+        * ReceiveHl7InXmlFormat.siddhi - Started Successfully!
+
+Testing the Sample:
+    1) In the HAPI testpanel create a sending connection with port that provided in the siddhi app.
+    2) Send this message 'MSH|^~\&|sendingSystemA|senderFacilityA|receivingSystemB|receivingFacilityB|20080925161613||ADT^A01|589888ADT30502184808|P|2.3' from the testpanel
+
+Viewing the Results:
+    See the output. Following message would be shown on the console if you publish events.
+    ReceiveHl7InXmlFormat : er7Stream : Event{timestamp=1552532452870, data=[589888ADT30502184808, sendingSystemA], isExpired=false}
+
+*/
+
+@source(type = 'hl7', port = '4000', hl7.encoding = 'xml', @map(type = 'xml', namespaces = 'ns=urn:hl7-org:v2xml', @attributes(MSH10 = "ns:MSH/ns:MSH.10", MSH3HD1 = "ns:MSH/ns:MSH.3/ns:HD.1")))
+define stream hl7stream (MSH10 string, MSH3HD1 string);
+
+@sink(type='log')
+define stream xmlStream (MSH10 string, MSH3HD1 string);
+
+@info(name='query1')
+from hl7stream
+select *
+insert into xmlStream;

--- a/modules/samples/artifacts/ReceiveHl7InXmlFormat/ReceiveHl7InXmlFormat.siddhi
+++ b/modules/samples/artifacts/ReceiveHl7InXmlFormat/ReceiveHl7InXmlFormat.siddhi
@@ -2,7 +2,6 @@
 @App:description('This receives the HL7 messages and sends the acknowledgement message to the client using the MLLP protocol and custom xml mapping.')
 
 /*
-
 Purpose:
 	This application demonstrates how to configure WSO2 Stream Processor to receive Hl7 events in XML format to the hl7Stream via MLLP protocol and log the events in xmlStream to the output console.
 
@@ -24,7 +23,6 @@ Testing the Sample:
 Viewing the Results:
     See the output. Following message would be shown on the console if you publish events.
     ReceiveHl7InXmlFormat : er7Stream : Event{timestamp=1552532452870, data=[589888ADT30502184808, sendingSystemA], isExpired=false}
-
 */
 
 @source(type = 'hl7', port = '4000', hl7.encoding = 'xml', @map(type = 'xml', namespaces = 'ns=urn:hl7-org:v2xml', @attributes(MSH10 = "ns:MSH/ns:MSH.10", MSH3HD1 = "ns:MSH/ns:MSH.3/ns:HD.1")))

--- a/modules/samples/artifacts/ReceiveHl7InXmlFormat/ReceiveHl7InXmlFormat.siddhi
+++ b/modules/samples/artifacts/ReceiveHl7InXmlFormat/ReceiveHl7InXmlFormat.siddhi
@@ -13,8 +13,8 @@ Prerequisites:
 Executing the Sample:
 	1) Start the Siddhi application by clicking on 'Run'.
 	2) If the Siddhi application starts successfully, the following messages would be shown on the console.
-        * Starting SimpleServer running on port 5000
-        * ReceiveHl7InXmlFormat.siddhi - Started Successfully!
+	    * Starting SimpleServer running on port 4000
+	    * ReceiveHl7InXmlFormat.siddhi - Started Successfully!
 
 Testing the Sample:
     1) In the HAPI testpanel create a sending connection with port that provided in the siddhi app.

--- a/modules/samples/artifacts/ReceiveHl7InXmlFormat/ReceiveHl7InXmlFormat.siddhi
+++ b/modules/samples/artifacts/ReceiveHl7InXmlFormat/ReceiveHl7InXmlFormat.siddhi
@@ -6,9 +6,9 @@ Purpose:
 	This application demonstrates how to configure WSO2 Stream Processor to receive Hl7 events in XML format to the hl7Stream via MLLP protocol and log the events in xmlStream to the output console.
 
 Prerequisites:
-    * Install the HAPI testpanel. (Reference: https://hapifhir.github.io/hapi-hl7v2/hapi-testpanel/install.html)
-    * Save this sample. If there is no syntax error, the following message is shown on the console:
-	     * - Siddhi App ReceiveHl7InXmlFormat successfully deployed.
+    1) Install the HAPI testpanel. (Reference: https://hapifhir.github.io/hapi-hl7v2/hapi-testpanel/install.html)
+    2) Save this sample. If there is no syntax error, the following message is shown on the console:
+        * - Siddhi App ReceiveHl7InXmlFormat successfully deployed.
 
 Executing the Sample:
 	1) Start the Siddhi application by clicking on 'Run'.


### PR DESCRIPTION
## Purpose
  The samples with instructions of how to publish and receive events using siddhi-io-hl7 for ER7 and XML format messages.

## Goals
 To easy to understand how hl7 works with siddhi.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
 Samples related to publish hl7 message to hl7 server and receive hl7 messages from the hl7 client using HAPI Test panel.
