### PR TITLE
Add Health Check API related features to distribution

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -157,10 +157,16 @@
             <artifactId>org.wso2.carbon.event.simulator.core.feature</artifactId>
             <type>zip</type>
         </dependency>
-
         <dependency>
             <groupId>org.wso2.carbon.analytics</groupId>
             <artifactId>org.wso2.carbon.siddhi.store.api.rest.feature</artifactId>
+            <type>zip</type>
+        </dependency>
+
+        <!-- Health Check API related -->
+        <dependency>
+            <groupId>org.wso2.carbon.analytics</groupId>
+            <artifactId>org.wso2.carbon.health.check.core.feature</artifactId>
             <type>zip</type>
         </dependency>
 
@@ -944,6 +950,12 @@
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
 
+                                <!-- Health Check API feature -->
+                                <feature>
+                                    <id>org.wso2.carbon.health.check.core.feature</id>
+                                    <version>${carbon.analytics.version}</version>
+                                </feature>
+
                                 <!-- Distributed Resource/Manager features -->
                                 <feature>
                                     <id>org.wso2.carbon.sp.jobmanager.core.feature</id>
@@ -1267,6 +1279,12 @@
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
 
+                                <!-- Health Check API feature -->
+                                <feature>
+                                    <id>org.wso2.carbon.health.check.core.feature</id>
+                                    <version>${carbon.analytics.version}</version>
+                                </feature>
+
                                 <!-- Authentication feature -->
                                 <feature>
                                     <id>org.wso2.carbon.analytics.msf4j.interceptor.common.feature</id>
@@ -1400,6 +1418,12 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.siddhi.feature.group</id>
+                                    <version>${carbon.analytics.version}</version>
+                                </feature>
+
+                                <!-- Health Check API feature -->
+                                <feature>
+                                    <id>org.wso2.carbon.health.check.core.feature</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
 
@@ -1805,6 +1829,12 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.business.rules.web.feature.group</id>
+                                    <version>${carbon.analytics.version}</version>
+                                </feature>
+
+                                <!-- Health Check API feature -->
+                                <feature>
+                                    <id>org.wso2.carbon.health.check.core.feature</id>
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
 

--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,14 @@
                 <type>zip</type>
             </dependency>
 
+            <!-- Health Check API related -->
+            <dependency>
+                <groupId>org.wso2.carbon.analytics</groupId>
+                <artifactId>org.wso2.carbon.health.check.core.feature</artifactId>
+                <version>${carbon.analytics.version}</version>
+                <type>zip</type>
+            </dependency>
+
             <!-- Siddhi Editor related -->
             <dependency>
                 <groupId>org.wso2.carbon.analytics</groupId>
@@ -1316,7 +1324,7 @@
     </build>
     <properties>
 
-        <carbon.analytics.version>2.0.506</carbon.analytics.version>
+        <carbon.analytics.version>2.0.511</carbon.analytics.version>
         <siddhi.version>4.5.0</siddhi.version>
 
         <carbon.analytics-common.version>6.1.4</carbon.analytics-common.version>
@@ -1355,9 +1363,9 @@
         <carbon.cache.version>1.1.3</carbon.cache.version>
         <carbon.touchpoint.version>1.1.1</carbon.touchpoint.version>
         <carbon.utils.version>2.0.8</carbon.utils.version>
-        <carbon.config.version>2.1.5</carbon.config.version>
+        <carbon.config.version>2.1.11</carbon.config.version>
         <carbon.config.version.range>[2.1.0, 3.0.0)</carbon.config.version.range>
-        <carbon.securevault.version>5.0.12</carbon.securevault.version>
+        <carbon.securevault.version>5.0.13</carbon.securevault.version>
 
         <slf4j.version>1.7.5</slf4j.version>
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)


### PR DESCRIPTION
## Purpose
> Health Check API to check whether Server is healthy or not. It is a simple HTTP, GET api service. There is no any credentials required to access this service.

## Approach
```
curl -k -X GET http://localhost:9090/health
```

## Documentation
> Refer API details in https://github.com/wso2/carbon-analytics/blob/master/components/org.wso2.carbon.health.check.core/src/main/resources/health-check-rest-api.yaml